### PR TITLE
strip symbols and debugging info from go binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN go mod download
 COPY . .
 ARG VERSION=unknown
 RUN go test ./...
-RUN go install -mod=readonly -ldflags "-X main.version=$VERSION" .
+RUN go install -mod=readonly -ldflags "-w -s -X main.version=$VERSION" .
 
 
 FROM node:18-buster AS frontend-builder


### PR DESCRIPTION
we probably don't need the symbols table or debugging info in the compiled go binary, so this commit removes them and reduces the final docker image size by about 10MB.

```
$ docker images | grep coroot
coroot-strip-binary             latest            62953c057fe3   19 minutes ago   182MB
coroot-original                 latest            436ad9054a5a   25 minutes ago   193MB
```