### PR TITLE
Initial support for Amazon Elasticache clusters

### DIFF
--- a/auditor/instances.go
+++ b/auditor/instances.go
@@ -32,6 +32,15 @@ func (a *appAuditor) instances() {
 			default:
 				status.SetStatus(model.OK, i.Rds.Status.Value())
 			}
+		} else if i.Elasticache != nil {
+			switch {
+			case timeseries.IsNaN(i.Elasticache.LifeSpan.Last()):
+				status.SetStatus(model.WARNING, "down (no metrics)")
+			case i.Elasticache.Status.Value() != "available":
+				status.SetStatus(model.WARNING, i.Elasticache.Status.Value())
+			default:
+				status.SetStatus(model.OK, i.Elasticache.Status.Value())
+			}
 		} else if i.Pod == nil {
 			if i.IsUp() {
 				status.SetStatus(model.OK, "ok")

--- a/constructor/elasticache.go
+++ b/constructor/elasticache.go
@@ -1,0 +1,64 @@
+package constructor
+
+import (
+	"github.com/coroot/coroot/model"
+	"github.com/coroot/coroot/timeseries"
+	"strings"
+)
+
+func loadElasticacheMetadata(w *model.World, metrics map[string][]model.MetricValues, pjs promJobStatuses, ecInstancesById map[string]*model.Instance) {
+	for _, m := range metrics["aws_elasticache_info"] {
+		ecId := m.Labels["ec_instance_id"]
+		if ecId == "" {
+			continue
+		}
+		instance := ecInstancesById[ecId]
+		if instance == nil {
+			var id model.ApplicationId
+			instanceParts := strings.SplitN(ecId, "/", 3)
+			if len(instanceParts) != 3 {
+				continue
+			}
+			id = model.NewApplicationId("", model.ApplicationKindElasticacheCluster, m.Labels["cluster_id"])
+			instance = w.GetOrCreateApplication(id).GetOrCreateInstance(instanceParts[1], nil)
+			ecInstancesById[ecId] = instance
+			instance.Elasticache = &model.Elasticache{}
+		}
+		if instance.Node == nil {
+			instance.Node = model.NewNode("elasticache:" + instance.Name)
+			instance.Node.Name.Update(m.Values, "elasticache:"+instance.Name)
+			instance.Node.Instances = append(instance.Node.Instances, instance)
+			w.Nodes = append(w.Nodes, instance.Node)
+		}
+		instance.TcpListens[model.Listen{IP: m.Labels["ipv4"], Port: m.Labels["port"]}] = true
+		instance.Elasticache.Engine.Update(m.Values, m.Labels["engine"])
+		instance.Elasticache.EngineVersion.Update(m.Values, m.Labels["engine_version"])
+		instance.Node.InstanceType.Update(m.Values, m.Labels["instance_type"])
+		instance.Node.CloudProvider.Update(m.Values, "aws")
+		instance.Node.Region.Update(m.Values, m.Labels["region"])
+		instance.Node.AvailabilityZone.Update(m.Values, m.Labels["availability_zone"])
+	}
+}
+
+func loadElasticache(w *model.World, metrics map[string][]model.MetricValues, pjs promJobStatuses, ecInstancesById map[string]*model.Instance) {
+	for queryName := range QUERIES {
+		if !strings.HasPrefix(queryName, "aws_elasticache_") || queryName == "aws_elasticache_info" {
+			continue
+		}
+		for _, m := range metrics[queryName] {
+			ecId := m.Labels["ec_instance_id"]
+			if ecId == "" {
+				continue
+			}
+			instance := ecInstancesById[ecId]
+			if instance == nil {
+				continue
+			}
+			switch queryName {
+			case "aws_elasticache_status":
+				instance.Elasticache.LifeSpan = merge(instance.Elasticache.LifeSpan, m.Values, timeseries.Any)
+				instance.Elasticache.Status.Update(m.Values, m.Labels["status"])
+			}
+		}
+	}
+}

--- a/constructor/queries.go
+++ b/constructor/queries.go
@@ -126,6 +126,9 @@ var QUERIES = map[string]string{
 	"aws_rds_net_rx_bytes_per_second":     `aws_rds_net_rx_bytes_per_second`,
 	"aws_rds_net_tx_bytes_per_second":     `aws_rds_net_tx_bytes_per_second`,
 
+	"aws_elasticache_info":   `aws_elasticache_info`,
+	"aws_elasticache_status": `aws_elasticache_status`,
+
 	"pg_connections":                  `pg_connections{db!="postgres"}`,
 	"pg_up":                           `pg_up`,
 	"pg_info":                         `pg_info`,

--- a/model/application.go
+++ b/model/application.go
@@ -82,6 +82,8 @@ func (app *Application) Labels() Labels {
 	switch app.Id.Kind {
 	case ApplicationKindRds:
 		res["db"] = fmt.Sprintf(`%s (RDS)`, app.Instances[0].Rds.Engine.Value())
+	case ApplicationKindElasticacheCluster:
+		res["db"] = fmt.Sprintf(`%s (EC)`, app.Instances[0].Elasticache.Engine.Value())
 	case ApplicationKindUnknown, ApplicationKindDockerSwarmService:
 		res["instances"] = strconv.Itoa(len(app.Instances))
 	case ApplicationKindExternalService:

--- a/model/aws.go
+++ b/model/aws.go
@@ -11,3 +11,12 @@ type Rds struct {
 
 	LifeSpan *timeseries.TimeSeries
 }
+
+type Elasticache struct {
+	Status LabelLastValue
+
+	Engine        LabelLastValue
+	EngineVersion LabelLastValue
+
+	LifeSpan *timeseries.TimeSeries
+}

--- a/model/instance.go
+++ b/model/instance.go
@@ -30,7 +30,8 @@ type Instance struct {
 
 	Pod *Pod
 
-	Rds *Rds
+	Rds         *Rds
+	Elasticache *Elasticache
 
 	Jvm *Jvm
 

--- a/model/kubernetes.go
+++ b/model/kubernetes.go
@@ -20,6 +20,7 @@ const (
 	ApplicationKindExternalService    ApplicationKind = "ExternalService"
 	ApplicationKindDatabaseCluster    ApplicationKind = "DatabaseCluster"
 	ApplicationKindRds                ApplicationKind = "RDS"
+	ApplicationKindElasticacheCluster ApplicationKind = "ElasticacheCluster"
 	ApplicationKindNode               ApplicationKind = "Node"
 )
 

--- a/model/node.go
+++ b/model/node.go
@@ -70,5 +70,10 @@ func NewNode(machineId string) *Node {
 }
 
 func (node *Node) IsUp() bool {
+	// currently, we don't collect OS metrics for Elasticache nodes
+	if len(node.Instances) == 1 && node.Instances[0].OwnerId.Kind == ApplicationKindElasticacheCluster {
+		return node.Instances[0].Elasticache.Status.Value() == "available"
+	}
+
 	return !DataIsMissing(node.CpuUsagePercent)
 }


### PR DESCRIPTION
This PR adds initial support for Amazon Elasticache clusters. 

Coroot uses metrics gathered by [aws-agent](https://coroot.com/docs/metric-exporters/aws-agent/overview) to monitor Redis and Memcached Elasticache clusters.

<img width="1181" alt="Screenshot 2023-06-05 at 13 40 03" src="https://github.com/coroot/coroot/assets/194465/aea1a907-65c5-4dfa-a20f-a380fe436c5c">



