### PR TITLE
TCP retransmissions

### DIFF
--- a/constructor/containers.go
+++ b/constructor/containers.go
@@ -109,6 +109,10 @@ func loadContainers(w *model.World, metrics map[string][]model.MetricValues, pjs
 				if !instance.TcpListens[l] {
 					instance.TcpListens[l] = isActive
 				}
+			case "container_net_tcp_retransmits":
+				if c := getOrCreateConnection(instance, container.Name, m, w, connectionCache); c != nil {
+					c.Retransmissions = merge(c.Retransmissions, m.Values, timeseries.Any)
+				}
 			case "container_http_requests_count", "container_postgres_queries_count", "container_redis_queries_count",
 				"container_memcached_queries_count", "container_mysql_queries_count", "container_mongo_queries_count",
 				"container_kafka_requests_count", "container_cassandra_queries_count", "container_rabbitmq_messages":

--- a/constructor/queries.go
+++ b/constructor/queries.go
@@ -55,6 +55,7 @@ var QUERIES = map[string]string{
 	"container_net_tcp_successful_connects": `rate(container_net_tcp_successful_connects_total[$RANGE])`,
 	"container_net_tcp_active_connections":  `container_net_tcp_active_connections`,
 	"container_net_tcp_listen_info":         `container_net_tcp_listen_info`,
+	"container_net_tcp_retransmits":         `rate(container_net_tcp_retransmits_total[$RANGE])`,
 	"container_log_messages":                `container_log_messages_total % 10000000`,
 	"container_application_type":            `container_application_type`,
 	"container_cpu_limit":                   `container_resources_cpu_limit_cores`,

--- a/model/connection.go
+++ b/model/connection.go
@@ -20,6 +20,8 @@ type Connection struct {
 	Connects *timeseries.TimeSeries
 	Active   *timeseries.TimeSeries
 
+	Retransmissions *timeseries.TimeSeries
+
 	RequestsCount     map[Protocol]map[string]*timeseries.TimeSeries // by status
 	RequestsLatency   map[Protocol]*timeseries.TimeSeries
 	RequestsHistogram map[Protocol]map[float32]*timeseries.TimeSeries // by le


### PR DESCRIPTION
This PR adds the "TCP retransmissions" chart to the Network inspection. The chart displays the number of retransmitted TCP segments per upstream service.

<img width="572" alt="Screenshot 2023-06-21 at 17 03 06" src="https://github.com/coroot/coroot/assets/194465/3f0fed14-3eea-49bf-9299-c3210c1bcf44">


