### PR TITLE
A suggestion to install aws-agent to instrument AWS RDS and AWS ElastiCache 

### DIFF
--- a/constructor/elasticache.go
+++ b/constructor/elasticache.go
@@ -34,7 +34,7 @@ func loadElasticacheMetadata(w *model.World, metrics map[string][]model.MetricVa
 		instance.Elasticache.Engine.Update(m.Values, m.Labels["engine"])
 		instance.Elasticache.EngineVersion.Update(m.Values, m.Labels["engine_version"])
 		instance.Node.InstanceType.Update(m.Values, m.Labels["instance_type"])
-		instance.Node.CloudProvider.Update(m.Values, "aws")
+		instance.Node.CloudProvider.Update(m.Values, model.CloudProviderAWS)
 		instance.Node.Region.Update(m.Values, m.Labels["region"])
 		instance.Node.AvailabilityZone.Update(m.Values, m.Labels["availability_zone"])
 	}

--- a/constructor/rds.go
+++ b/constructor/rds.go
@@ -45,7 +45,7 @@ func loadRdsMetadata(w *model.World, metrics map[string][]model.MetricValues, pj
 		instance.Rds.EngineVersion.Update(m.Values, m.Labels["engine_version"])
 		instance.Node.InstanceType.Update(m.Values, m.Labels["instance_type"])
 		instance.Volumes[0].EBS.StorageType.Update(m.Values, m.Labels["storage_type"])
-		instance.Node.CloudProvider.Update(m.Values, "aws")
+		instance.Node.CloudProvider.Update(m.Values, model.CloudProviderAWS)
 		instance.Node.Region.Update(m.Values, m.Labels["region"])
 		instance.Node.AvailabilityZone.Update(m.Values, m.Labels["availability_zone"])
 		instance.Rds.MultiAz.Update(m.Values, m.Labels["multi_az"])

--- a/front/src/views/ProjectStatus.vue
+++ b/front/src/views/ProjectStatus.vue
@@ -62,11 +62,15 @@
                 </v-btn>
                 (<a :href="`https://coroot.com/docs/metric-exporters/${ex.exporter}`" target="_blank">docs</a>)
                 <div class="ml-5">
-                    <span class="text-capitalize">{{ex.type}}</span> metrics have been received from
-                    {{ex.instrumentedApps}} of {{$pluralize('application', ex.totalApps, true)}}.
-                    <template v-if="ex.instrumentedApps < ex.totalApps">
-                        Get <span class="font-weight-medium">{{ex.exporter}}</span> <a :href="`https://coroot.com/docs/metric-exporters/${ex.exporter}/installation`" target="_blank">installed</a>
-                        for every following application:
+                    <span v-if="ex.details.description" v-html="ex.details.description"/>
+                    <template v-else>
+                        <span class="text-capitalize">{{ex.type}}</span> metrics have been received from
+                        {{ex.instrumentedApps}} of {{$pluralize('application', ex.totalApps, true)}}.
+                        <template v-if="ex.instrumentedApps < ex.totalApps">
+                            Get <span class="font-weight-medium">{{ex.details.exporter}} </span>
+                            <a :href="`https://coroot.com/docs/metric-exporters/${ex.details.exporter}/installation`" target="_blank">installed</a>
+                            for every following application:
+                        </template>
                     </template>
                 </div>
                 <div v-for="(ok, id) in ex.applications" :key="id" class="ml-5">
@@ -102,9 +106,11 @@ export default {
             if (!this.status || !this.status.application_exporters) {
                 return [];
             }
-            const exporters = {
-                postgres: 'pg-agent',
-                redis: 'redis-exporter',
+            const instructions = {
+                'postgres': {exporter: 'pg-agent'},
+                'redis': {exporter: 'redis-exporter'},
+                'aws-rds': {description: 'It appears that AWS RDS is being used in this project. Please ensure that <a href="https://coroot.com/docs/metric-exporters/aws-agent/installation">aws-agent</a> is installed.'},
+                'aws-elasticache': {description: 'It appears that AWS ElastiCache is being used in this project. Please ensure that <a href="https://coroot.com/docs/metric-exporters/aws-agent/installation">aws-agent</a> is installed.'},
             };
             const res = [];
             for (const type in this.status.application_exporters) {
@@ -112,10 +118,11 @@ export default {
                 const dd = Object.values(ex.applications);
                 const totalApps = dd.length;
                 const instrumentedApps = dd.filter(ok => ok).length;
+                const details = instructions[type] || {};
                 res.push({
                     ...ex,
                     type,
-                    exporter: exporters[type] || 'unknown',
+                    details,
                     totalApps,
                     instrumentedApps,
                 });

--- a/model/application_types.go
+++ b/model/application_types.go
@@ -16,6 +16,8 @@ const (
 	ApplicationTypeRabbitmq      ApplicationType = "rabbitmq"
 	ApplicationTypeKafka         ApplicationType = "kafka"
 	ApplicationTypeZookeeper     ApplicationType = "zookeeper"
+	ApplicationTypeRDS           ApplicationType = "aws-rds"
+	ApplicationTypeElastiCache   ApplicationType = "aws-elasticache"
 )
 
 func (at ApplicationType) IsDatabase() bool {

--- a/model/node.go
+++ b/model/node.go
@@ -4,6 +4,10 @@ import (
 	"github.com/coroot/coroot/timeseries"
 )
 
+const (
+	CloudProviderAWS = "aws"
+)
+
 type DiskStats struct {
 	IOUtilizationPercent *timeseries.TimeSeries
 	ReadOps              *timeseries.TimeSeries


### PR DESCRIPTION
This PR introduces a suggestion to install [aws-agent](https://github.com/coroot/coroot-aws-agent) when external services using the following ports are detected within the AWS cluster: 
* Port 5432 (RDS for Postgres)
* Port 3306 (RDS for MySQL)
* Port 11211 (ElastiCache for Memcached)
* Port 6379 (ElastiCache for Redis)

<img width="809" alt="Screenshot 2023-08-18 at 18 28 04" src="https://github.com/coroot/coroot/assets/194465/86322813-f462-47a8-944b-04f732b90ede">




