### PR TITLE
Disable validation webhook for msteams

### DIFF
--- a/notifications/teams.go
+++ b/notifications/teams.go
@@ -3,12 +3,11 @@ package notifications
 import (
 	"context"
 	"fmt"
-	"strings"
-
-	goteamsnotify "github.com/atc0005/go-teams-notify/v2"
+	"github.com/atc0005/go-teams-notify/v2"
 	"github.com/atc0005/go-teams-notify/v2/messagecard"
 	"github.com/coroot/coroot/db"
 	"github.com/coroot/coroot/model"
+	"strings"
 )
 
 type Teams struct {

--- a/notifications/teams.go
+++ b/notifications/teams.go
@@ -3,11 +3,12 @@ package notifications
 import (
 	"context"
 	"fmt"
-	"github.com/atc0005/go-teams-notify/v2"
+	"strings"
+
+	goteamsnotify "github.com/atc0005/go-teams-notify/v2"
 	"github.com/atc0005/go-teams-notify/v2/messagecard"
 	"github.com/coroot/coroot/db"
 	"github.com/coroot/coroot/model"
-	"strings"
 )
 
 type Teams struct {
@@ -16,9 +17,11 @@ type Teams struct {
 }
 
 func NewTeams(webhookUrl string) *Teams {
+	var client = goteamsnotify.NewTeamsClient()
+	client.SkipWebhookURLValidationOnSend(true)
 	return &Teams{
 		webhookUrl: webhookUrl,
-		client:     goteamsnotify.NewTeamsClient(),
+		client:     client,
 	}
 }
 


### PR DESCRIPTION
Disable validation webhook for msteams https://github.com/atc0005/go-teams-notify/tree/master#disable-webhook-url-prefix-validation 