### PR TITLE
prometheus cache improvements

### DIFF
--- a/cache/client.go
+++ b/cache/client.go
@@ -65,7 +65,7 @@ func (c *Client) GetStep(from, to timeseries.Time) (timeseries.Duration, error) 
 	var step timeseries.Duration
 	for _, qData := range projData.queries {
 		for _, ch := range qData.chunksOnDisk {
-			if ch.From > from || ch.To() < to {
+			if ch.From > to || ch.To() < from {
 				continue
 			}
 			if ch.Step > step {

--- a/cache/compaction.go
+++ b/cache/compaction.go
@@ -120,7 +120,12 @@ func (c *Cache) compact(t CompactionTask) error {
 	sort.Slice(t.src, func(i, j int) bool {
 		return t.src[i].From < t.src[j].From
 	})
-	step := t.src[0].Step
+	var step timeseries.Duration
+	for _, ch := range t.src {
+		if ch.Step > step {
+			step = ch.Step
+		}
+	}
 	pointsCount := int(t.compactor.DstChunkDuration / step)
 	for _, i := range t.src {
 		if err := chunk.Read(i.Path, t.dstChunk, pointsCount, step, metrics); err != nil {

--- a/timeseries/timeseries.go
+++ b/timeseries/timeseries.go
@@ -115,12 +115,12 @@ func (ts *TimeSeries) Fill(from Time, step Duration, data []float32) bool {
 			tNext = t.Truncate(ts.step)
 		}
 		if iNext < len(ts.data) {
-			ts.data[iNext] = data[i]
-			tNext = tNext.Add(ts.step)
-			iNext++
-			if !changed && !IsNaN(data[i]) {
+			if !IsNaN(data[i]) {
+				ts.data[iNext] = data[i]
 				changed = true
 			}
+			tNext = tNext.Add(ts.step)
+			iNext++
 		}
 	}
 	return changed


### PR DESCRIPTION
- fix cache step calculation
- use max step in compaction
- limit backfill by 4h
- don't overwrite data with NaNs