### PR TITLE
initial support for AWS Fargate

### DIFF
--- a/api/views/overview/nodes.go
+++ b/api/views/overview/nodes.go
@@ -20,7 +20,7 @@ func renderNodes(w *model.World) *model.Table {
 			continue
 		}
 
-		node := model.NewTableCell(name)
+		node := model.NewTableCell(name).SetMaxWidth(30)
 		node.Link = model.NewRouterLink(name).SetRoute("node").SetParam("name", name)
 		for _, t := range getNodeTags(n) {
 			node.AddTag(t)
@@ -81,7 +81,7 @@ func renderNodes(w *model.World) *model.Table {
 		table.AddRow(
 			node,
 			status,
-			model.NewTableCell(az).SetUnit("("+strings.ToLower(n.CloudProvider.Value())+")"),
+			model.NewTableCell(az).SetMaxWidth(20).SetUnit("("+strings.ToLower(n.CloudProvider.Value())+")"),
 			model.NewTableCell(ips.Items()...),
 			cpuPercent,
 			memoryPercent,

--- a/constructor/constructor.go
+++ b/constructor/constructor.go
@@ -103,11 +103,13 @@ func (c *Constructor) LoadWorld(ctx context.Context, from, to timeseries.Time, s
 	// order is important
 	prof.stage("load_job_statuses", func() { loadPromJobStatuses(metrics, pjs) })
 	prof.stage("load_nodes", func() { c.loadNodes(w, metrics, nodesByMachineId) })
+	prof.stage("load_fargate_nodes", func() { c.loadFargateNodes(metrics, nodesByMachineId) })
 	prof.stage("load_k8s_metadata", func() { loadKubernetesMetadata(w, metrics, servicesByClusterIP) })
 	prof.stage("load_rds_metadata", func() { loadRdsMetadata(w, metrics, pjs, rdsInstancesById) })
 	prof.stage("load_elasticache_metadata", func() { loadElasticacheMetadata(w, metrics, pjs, ecInstancesById) })
 	prof.stage("load_rds", func() { c.loadRds(w, metrics, pjs, rdsInstancesById) })
 	prof.stage("load_elasticache", func() { c.loadElasticache(w, metrics, pjs, ecInstancesById) })
+	prof.stage("load_fargate_containers", func() { loadFargateContainers(w, metrics, pjs) })
 	prof.stage("load_containers", func() { loadContainers(w, metrics, pjs, nodesByMachineId, servicesByClusterIP) })
 	prof.stage("enrich_instances", func() { enrichInstances(w, metrics, rdsInstancesById, ecInstancesById) })
 	prof.stage("join_db_cluster", func() { joinDBClusterComponents(w) })
@@ -157,7 +159,7 @@ func (c *Constructor) queryCache(ctx context.Context, from, to timeseries.Time, 
 			continue
 		}
 		addQuery(n, n, q, false)
-		if n == "container_memory_rss" {
+		if n == "container_memory_rss" || n == "fargate_container_memory_rss" {
 			name := n + "_for_trend"
 			queries[name] = cacheQuery{
 				query:     q,

--- a/constructor/fargate.go
+++ b/constructor/fargate.go
@@ -1,0 +1,100 @@
+package constructor
+
+import (
+	"fmt"
+	"github.com/coroot/coroot/model"
+	"github.com/coroot/coroot/timeseries"
+	"strings"
+)
+
+func (c *Constructor) loadFargateNodes(metrics map[string][]model.MetricValues, nodesByMachineId map[string]*model.Node) {
+	for queryName := range metrics {
+		if !strings.HasPrefix(queryName, "fargate_node_") {
+			continue
+		}
+		for _, m := range metrics[queryName] {
+			machineID := strings.Replace(m.Labels["system_uuid"], "-", "", -1)
+			if machineID == "" {
+				continue
+			}
+			node := nodesByMachineId[machineID]
+			if node == nil {
+				continue
+			}
+			if m.Labels["eks_amazonaws_com_compute_type"] != "fargate" {
+				continue
+			}
+			node.Fargate = true
+			node.Name.Update(m.Values, m.Labels["kubernetes_io_hostname"])
+			node.CloudProvider.Update(m.Values, model.CloudProviderAWS)
+			if region := m.Labels["topology_kubernetes_io_region"]; region != "" {
+				node.Region.Update(m.Values, region)
+			}
+			if az := m.Labels["topology_kubernetes_io_zone"]; az != "" {
+				node.Region.Update(m.Values, az)
+			}
+			switch queryName {
+			case "fargate_node_machine_cpu_cores":
+				node.CpuCapacity = merge(node.CpuCapacity, m.Values, timeseries.Any)
+			case "fargate_node_machine_memory_bytes":
+				node.MemoryTotalBytes = merge(node.MemoryTotalBytes, m.Values, timeseries.Any)
+			}
+		}
+	}
+}
+
+func loadFargateContainers(w *model.World, metrics map[string][]model.MetricValues, pjs promJobStatuses) {
+	var instances map[instanceId]*model.Instance
+	for queryName := range metrics {
+		if !strings.HasPrefix(queryName, "fargate_container_") {
+			continue
+		}
+		for _, m := range metrics[queryName] {
+			nodeName := m.Labels["kubernetes_io_hostname"]
+			if nodeName == "" {
+				continue
+			}
+			ns := m.Labels["namespace"]
+			pod := m.Labels["pod"]
+			containerName := m.Labels["container"]
+
+			if ns == "" || pod == "" || containerName == "" {
+				continue
+			}
+			if instances == nil {
+				instances = map[instanceId]*model.Instance{}
+				for _, a := range w.Applications {
+					for _, i := range a.Instances {
+						if n := i.NodeName(); n != "" {
+							instances[instanceId{ns: a.Id.Namespace, name: i.Name, node: n}] = i
+						}
+					}
+				}
+			}
+			instance := instances[instanceId{ns: ns, name: pod, node: nodeName}]
+			if instance == nil {
+				continue
+			}
+			container := instance.GetOrCreateContainer(fmt.Sprintf("/k8s/%s/%s/%s", ns, pod, containerName), containerName)
+
+			switch queryName {
+			case "fargate_container_spec_cpu_limit_cores":
+				container.CpuLimit = merge(container.CpuLimit, m.Values, timeseries.Any)
+			case "fargate_container_cpu_usage_seconds":
+				container.CpuUsage = merge(container.CpuUsage, m.Values, timeseries.Any)
+			case "fargate_container_cpu_cfs_throttled_seconds":
+				container.ThrottledTime = merge(container.ThrottledTime, m.Values, timeseries.Any)
+			case "fargate_container_memory_rss":
+				container.MemoryRss = merge(container.MemoryRss, m.Values, timeseries.Any)
+			case "fargate_container_memory_rss_for_trend":
+				container.MemoryRssForTrend = merge(container.MemoryRssForTrend, m.Values, timeseries.Any)
+			case "fargate_container_memory_cache":
+				container.MemoryCache = merge(container.MemoryCache, m.Values, timeseries.Any)
+			case "fargate_container_spec_memory_limit_bytes":
+				container.MemoryLimit = merge(container.MemoryLimit, m.Values, timeseries.Any)
+			case "fargate_container_oom_events_total":
+				container.OOMKills = merge(container.OOMKills, timeseries.Increase(m.Values, pjs.get(m.Labels)), timeseries.Any)
+			}
+		}
+	}
+}

--- a/constructor/k8s.go
+++ b/constructor/k8s.go
@@ -118,7 +118,8 @@ func podInfo(w *model.World, metrics []model.MetricValues) map[string]*model.Ins
 
 		podIp := m.Labels["pod_ip"]
 		hostIp := m.Labels["host_ip"]
-		if podIp != "" && podIp != hostIp {
+
+		if podIp != "" && (podIp != hostIp || (node != nil && node.Fargate)) {
 			if ip := net.ParseIP(podIp); ip != nil {
 				isActive := m.Values.Last() == 1
 				instance.TcpListens[model.Listen{IP: podIp, Port: "0", Proxied: false}] = isActive

--- a/constructor/queries.go
+++ b/constructor/queries.go
@@ -41,6 +41,17 @@ var QUERIES = map[string]string{
 	"node_net_rx_bytes":           `rate(node_net_received_bytes_total[$RANGE])`,
 	"node_net_tx_bytes":           `rate(node_net_transmitted_bytes_total[$RANGE])`,
 
+	"fargate_node_machine_cpu_cores":    `machine_cpu_cores{eks_amazonaws_com_compute_type="fargate"}`,
+	"fargate_node_machine_memory_bytes": `machine_memory_bytes{eks_amazonaws_com_compute_type="fargate"}`,
+
+	"fargate_container_spec_memory_limit_bytes":   `container_spec_memory_limit_bytes{eks_amazonaws_com_compute_type="fargate"}`,
+	"fargate_container_spec_cpu_limit_cores":      `container_spec_cpu_quota{eks_amazonaws_com_compute_type="fargate"}/container_spec_cpu_period{eks_amazonaws_com_compute_type="fargate"}`,
+	"fargate_container_oom_events_total":          `container_oom_events_total{eks_amazonaws_com_compute_type="fargate"}`,
+	"fargate_container_memory_rss":                `container_memory_rss{eks_amazonaws_com_compute_type="fargate"}`,
+	"fargate_container_memory_cache":              `container_memory_cache{eks_amazonaws_com_compute_type="fargate"}`,
+	"fargate_container_cpu_usage_seconds":         `rate(container_cpu_usage_seconds_total{eks_amazonaws_com_compute_type="fargate"}[$RANGE])`,
+	"fargate_container_cpu_cfs_throttled_seconds": `rate(container_cpu_cfs_throttled_seconds_total{eks_amazonaws_com_compute_type="fargate"}[$RANGE])`,
+
 	"kube_node_info":    `kube_node_info`,
 	"kube_service_info": `kube_service_info`,
 

--- a/front/src/components/Table.vue
+++ b/front/src/components/Table.vue
@@ -41,18 +41,16 @@
                     </router-link>
                 </div>
 
-                <div v-else class="d-flex">
-                    <div>
+                <div v-else>
+                    <div class="d-flex">
                         <v-icon v-if="c.icon" :color="c.icon.color" small class="mr-1">{{c.icon.name}}</v-icon>
                         <Led v-if="c.status && c.value" :status="c.status" />
-                    </div>
-                    <div>
-                        <router-link v-if="c.value && c.link" :to="{...{query: $route.query}, ...c.link}">{{c.value}}</router-link>
-                        <span v-else :class="{'grey--text': c.is_stub}">{{(smallScreen && c.short_value ? c.short_value : c.value) || '&mdash;'}}</span>
+                        <router-link v-if="c.value && c.link" :to="{...{query: $route.query}, ...c.link}" :class="{'truncated': !!c.max_width}" :style="{'max-width': c.max_width || undefined}">{{c.value}}</router-link>
+                        <span v-else :class="{'grey--text': c.is_stub, 'truncated': !!c.max_width}" :style="{'max-width': c.max_width || undefined}">{{(smallScreen && c.short_value ? c.short_value : c.value) || '&mdash;'}}</span>
                         <span v-if="c.unit && c.value" class="caption grey--text ml-1">{{c.unit}}</span>
-                        <div v-if="c.tags && !smallScreen">
-                            <span v-for="t in c.tags" class="tag">{{t}}</span>
-                        </div>
+                    </div>
+                    <div v-if="c.tags && !smallScreen">
+                        <span v-for="t in c.tags" class="tag">{{t}}</span>
                     </div>
                 </div>
             </td>
@@ -90,5 +88,12 @@ export default {
 }
 .tag:not(:last-child):after {
     content: " / ";
+}
+.truncated {
+    max-width: 30ch;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: block;
 }
 </style>

--- a/model/node.go
+++ b/model/node.go
@@ -57,7 +57,8 @@ type Node struct {
 	InstanceType      LabelLastValue
 	InstanceLifeCycle LabelLastValue
 
-	Price *NodePrice
+	Fargate bool
+	Price   *NodePrice
 }
 
 type NodePrice struct {
@@ -94,7 +95,7 @@ func (n *Node) IsUp() bool {
 		return n.Instances[0].Elasticache.Status.Value() == "available"
 	}
 
-	return !n.CpuUsagePercent.TailIsEmpty()
+	return !n.MemoryTotalBytes.TailIsEmpty()
 }
 
 func (n *Node) IsDown() bool {

--- a/model/table.go
+++ b/model/table.go
@@ -84,6 +84,7 @@ type TableCell struct {
 	NetInterfaces []NetInterface         `json:"net_interfaces"`
 	Chart         *timeseries.TimeSeries `json:"chart"`
 	IsStub        bool                   `json:"is_stub"`
+	MaxWidth      int                    `json:"max_width"`
 
 	DeploymentSummaries []ApplicationDeploymentSummary `json:"deployment_summaries"`
 }
@@ -184,6 +185,14 @@ func (c *TableCell) SetStub(format string, a ...any) *TableCell {
 	}
 	c.Value = fmt.Sprintf(format, a...)
 	c.IsStub = true
+	return c
+}
+
+func (c *TableCell) SetMaxWidth(w int) *TableCell {
+	if c == nil {
+		return nil
+	}
+	c.MaxWidth = w
 	return c
 }
 


### PR DESCRIPTION
This PR introduces initial support for AWS Fargate. Coroot uses metrics collected from the Cadvisor integrated into Fargate "nodes".