### PR TITLE
Move from io/ioutil to io and os packages

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -8,7 +8,7 @@ import (
 	"github.com/coroot/coroot/prom"
 	"github.com/coroot/coroot/timeseries"
 	"github.com/prometheus/client_golang/prometheus"
-	"io/ioutil"
+	"os"
 	"k8s.io/klog"
 	"path"
 	"strings"
@@ -121,7 +121,7 @@ func (c *Cache) Updates() <-chan db.ProjectId {
 
 func (c *Cache) initCacheIndexFromDir() error {
 	t := time.Now()
-	files, err := ioutil.ReadDir(c.cfg.Path)
+	files, err := os.ReadDir(c.cfg.Path)
 	if err != nil {
 		return err
 	}
@@ -131,7 +131,7 @@ func (c *Cache) initCacheIndexFromDir() error {
 		}
 		projectId := f.Name()
 		projectDir := path.Join(c.cfg.Path, projectId)
-		projFiles, err := ioutil.ReadDir(projectDir)
+		projFiles, err := os.ReadDir(projectDir)
 		if err != nil {
 			return err
 		}

--- a/cache/updater.go
+++ b/cache/updater.go
@@ -11,7 +11,6 @@ import (
 	"github.com/coroot/coroot/timeseries"
 	"github.com/coroot/coroot/utils"
 	promModel "github.com/prometheus/common/model"
-	"io/ioutil"
 	"k8s.io/klog"
 	"math"
 	"os"
@@ -253,7 +252,7 @@ func (c *Cache) writeChunk(projectId db.ProjectId, queryHash string, from timese
 	if dir == "" {
 		dir = "."
 	}
-	f, err := ioutil.TempFile(dir, file)
+	f, err := os.CreateTemp(dir, file)
 	if err != nil {
 		return err
 	}

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -15,7 +15,7 @@ import (
 	"github.com/coroot/coroot/utils"
 	"github.com/prometheus/procfs"
 	"github.com/pyroscope-io/godeltaprof"
-	"io/ioutil"
+	"io"
 	"k8s.io/klog"
 	"net/http"
 	"runtime/pprof"
@@ -128,7 +128,7 @@ func NewCollector(instanceUuid, version string, db *db.DB, cache *cache.Cache, p
 		heapProfiler: godeltaprof.NewHeapProfiler(),
 	}
 
-	if err := c.heapProfiler.Profile(ioutil.Discard); err != nil {
+	if err := c.heapProfiler.Profile(io.Discard); err != nil {
 		klog.Warningln(err)
 	}
 

--- a/utils/json.go
+++ b/utils/json.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"k8s.io/klog"
 	"net/http"
 )
@@ -19,7 +19,7 @@ func WriteJson(w http.ResponseWriter, v any) {
 }
 
 func ReadJson(r *http.Request, dest any) error {
-	if body, err := ioutil.ReadAll(r.Body); err != nil {
+	if body, err := io.ReadAll(r.Body); err != nil {
 		return fmt.Errorf(`failed to read body: %w`, err)
 	} else if err := json.Unmarshal(body, dest); err != nil {
 		return fmt.Errorf("failed to unmarshal body: %w", err)


### PR DESCRIPTION
The `io/ioutil` package has been deprecated as of Go 1.16 [^1]. This commit replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

[^1]: https://golang.org/doc/go1.16#ioutil