### PR TITLE
DNS monitoring

### DIFF
--- a/api/views/overview/health.go
+++ b/api/views/overview/health.go
@@ -26,6 +26,7 @@ type ApplicationStatus struct {
 	DiskIO    ApplicationParam `json:"disk_io"`
 	DiskUsage ApplicationParam `json:"disk_usage"`
 	Network   ApplicationParam `json:"network"`
+	DNS       ApplicationParam `json:"dns"`
 	Logs      ApplicationParam `json:"logs"`
 }
 
@@ -140,6 +141,18 @@ func renderHealth(w *model.World) []*ApplicationStatus {
 					if ch.Status >= model.WARNING {
 						a.Network.Status = ch.Status
 						a.Network.Value = "failed conns"
+					}
+				case model.Checks.DnsLatency.Id:
+					if ch.Status >= model.WARNING {
+						a.DNS.Status = ch.Status
+						if ch.Value() > 0 {
+							a.DNS.Value = utils.FormatLatency(ch.Value())
+						}
+					}
+				case model.Checks.DnsServerErrors.Id, model.Checks.DnsNxdomainErrors.Id:
+					if ch.Status >= model.WARNING {
+						a.DNS.Status = ch.Status
+						a.DNS.Value = "errors"
 					}
 				case model.Checks.LogErrors.Id:
 					if items := ch.Items(); items != nil && items.Len() > 0 {

--- a/auditor/auditor.go
+++ b/auditor/auditor.go
@@ -33,6 +33,7 @@ func Audit(w *model.World, p *db.Project, generateDetailedReportFor *model.Appli
 		a.memory(ncs)
 		a.storage()
 		a.network()
+		a.dns()
 		a.postgres()
 		a.redis()
 		a.mongodb()

--- a/auditor/deployments.go
+++ b/auditor/deployments.go
@@ -15,7 +15,7 @@ func (a *appAuditor) deployments() {
 
 	statusCheck := report.CreateCheck(model.Checks.DeploymentStatus)
 
-	table := report.GetOrCreateTable("Deployment", "Deployed", "Summary").SetSorted(true)
+	table := report.GetOrCreateTable("Deployment", "Deployed", "Summary").SetSorted()
 
 	now := timeseries.Now()
 	statuses := model.CalcApplicationDeploymentStatuses(a.app, a.w.CheckConfigs, now)

--- a/auditor/dns.go
+++ b/auditor/dns.go
@@ -1,0 +1,199 @@
+package auditor
+
+import (
+	"math"
+	"sort"
+
+	"github.com/coroot/coroot/model"
+	"github.com/coroot/coroot/timeseries"
+)
+
+type DnsTypeStats struct {
+	Requests uint64
+	NxDomain uint64
+	ServFail uint64
+}
+
+func (st DnsTypeStats) Nxdomain() uint64 {
+	if st.Requests == st.NxDomain { // we haven't seen OK responses
+		return 0
+	}
+	return st.NxDomain
+}
+
+type DNSStats struct {
+	Domain string
+	A      DnsTypeStats
+	AAAA   DnsTypeStats
+	Other  DnsTypeStats
+}
+
+func (a *appAuditor) dns() {
+	report := a.addReport(model.AuditReportDNS)
+	latencyCheck := report.CreateCheck(model.Checks.DnsLatency)
+	serverErrorsCheck := report.CreateCheck(model.Checks.DnsServerErrors)
+	nxdomainCheck := report.CreateCheck(model.Checks.DnsNxdomainErrors)
+
+	table := report.
+		GetOrCreateTable("Domain", "Requests", "No results (IPv4: A)", "No results (IPv6: AAAA)", "No results (other)", "ServFail").
+		SetSorted()
+
+	requestsChart := report.GetOrCreateChart(
+		"DNS requests by type, per second",
+		nil,
+	)
+	errorsChart := report.GetOrCreateChart(
+		"DNS errors, per second",
+		nil,
+	)
+	latencyChart := report.GetOrCreateChart(
+		"DNS latency, seconds",
+		nil,
+	)
+	hist := map[float32]*timeseries.Aggregate{}
+	byType := map[string]*timeseries.Aggregate{}
+	errors := map[string]*timeseries.Aggregate{}
+	byDomain := map[string]*DNSStats{}
+
+	seenDNSRequests := false
+	for _, instance := range a.app.Instances {
+		for _, container := range instance.Containers {
+			for r, byStatus := range container.DNSRequests {
+				for status, ts := range byStatus {
+					if !seenDNSRequests && ts.Reduce(timeseries.NanSum) > 0 {
+						seenDNSRequests = true
+					}
+					d := byDomain[r.Domain]
+					if d == nil {
+						d = &DNSStats{Domain: r.Domain}
+						byDomain[r.Domain] = d
+					}
+					v := ts.Reduce(timeseries.NanSum)
+					if timeseries.IsNaN(v) {
+						continue
+					}
+					total := uint64(math.Round(float64(v) * float64(a.w.Ctx.Step)))
+					var st *DnsTypeStats
+					switch r.Type {
+					case "TypeA":
+						st = &d.A
+					case "TypeAAAA":
+
+						st = &d.AAAA
+					default:
+						st = &d.Other
+					}
+					st.Requests += total
+					switch status {
+					case "ok":
+					case "nxdomain":
+						st.NxDomain += total
+					default:
+						serverErrorsCheck.Inc(int64(total))
+						st.ServFail += total
+					}
+					if requestsChart != nil {
+						t := byType[r.Type]
+						if t == nil {
+							t = timeseries.NewAggregate(timeseries.NanSum)
+							byType[r.Type] = t
+						}
+						t.Add(ts)
+
+						if status != "ok" {
+							label := r.Type + ":" + status
+							e := errors[label]
+							if e == nil {
+								e = timeseries.NewAggregate(timeseries.NanSum)
+								errors[label] = e
+							}
+							e.Add(ts)
+						}
+					}
+				}
+			}
+			for b, ts := range container.DNSRequestsHistogram {
+				v := hist[b]
+				if v == nil {
+					v = timeseries.NewAggregate(timeseries.NanSum)
+					hist[b] = v
+				}
+				v.Add(ts)
+			}
+		}
+	}
+
+	buckets := make([]model.HistogramBucket, 0, len(hist))
+	for le, ts := range hist {
+		buckets = append(buckets, model.HistogramBucket{Le: le, TimeSeries: ts.Get()})
+	}
+	sort.Slice(buckets, func(i, j int) bool {
+		return buckets[i].Le < buckets[j].Le
+	})
+
+	domains := make([]*DNSStats, 0, len(byDomain))
+	for _, d := range byDomain {
+		domains = append(domains, d)
+	}
+	sort.Slice(domains, func(i, j int) bool {
+		di := domains[i]
+		dj := domains[j]
+		return (di.A.Requests + di.AAAA.Requests + di.Other.Requests) > (dj.A.Requests + dj.AAAA.Requests + dj.Other.Requests)
+	})
+	for i, d := range domains {
+		req := d.A.Requests + d.AAAA.Requests + d.Other.Requests
+		if req < 1 {
+			continue
+		}
+		status := model.OK
+		if nxdomainErrors := d.A.Nxdomain() + d.AAAA.Nxdomain() + d.Other.Nxdomain(); nxdomainErrors > 0 {
+			status = model.WARNING
+			nxdomainCheck.Inc(int64(nxdomainErrors))
+		}
+		if d.A.ServFail > 0 || d.AAAA.ServFail > 0 || d.Other.ServFail > 0 {
+			status = model.WARNING
+		}
+		if status == model.OK && (d.A.NxDomain+d.AAAA.NxDomain+d.Other.NxDomain) == req {
+			status = model.UNKNOWN
+		}
+
+		if table != nil {
+			if (i + 1) <= 10 {
+				table.Rows = append(table.Rows, &model.TableRow{Cells: []*model.TableCell{
+					model.NewTableCell().SetStatus(status, d.Domain),
+					model.NewTableCell().SetEventsCount(req),
+					model.NewTableCell().SetEventsCount(d.A.NxDomain),
+					model.NewTableCell().SetEventsCount(d.AAAA.NxDomain),
+					model.NewTableCell().SetEventsCount(d.Other.NxDomain),
+					model.NewTableCell().SetEventsCount(d.A.ServFail + d.AAAA.ServFail + d.Other.ServFail),
+				}})
+			}
+		}
+	}
+	if requestsChart != nil {
+		requestsChart.Stacked()
+		for typ, ts := range byType {
+			requestsChart.AddSeries(typ, ts)
+		}
+	}
+	if errorsChart != nil {
+		errorsChart.Stacked()
+		for e, ts := range errors {
+			errorsChart.AddSeries(e, ts)
+		}
+	}
+	if latencyChart != nil {
+		latencyChart.PercentilesFrom(buckets, 0.5, 0.95, 0.99)
+	}
+
+	if len(buckets) > 0 {
+		q95 := model.Quantile(buckets, 0.95)
+		if l := q95.Last(); !timeseries.IsNaN(l) {
+			latencyCheck.SetValue(l)
+		}
+	}
+
+	if !seenDNSRequests {
+		a.delReport(model.AuditReportDNS)
+	}
+}

--- a/auditor/slo.go
+++ b/auditor/slo.go
@@ -14,7 +14,7 @@ type sumFromFunc func(from timeseries.Time) float32
 
 func (a *appAuditor) slo() {
 	report := a.addReport(model.AuditReportSLO)
-	requestsChart(a.app, report, a.p)
+	sloRequestsChart(a.app, report, a.p)
 	availability(a.w.Ctx, a.app, report)
 	latency(a.w.Ctx, a.app, report)
 	clientRequests(a.app, report)
@@ -155,7 +155,7 @@ func calcBurnRates(now timeseries.Time, badSum, totalSum sumFromFunc, objectiveP
 	return first
 }
 
-func requestsChart(app *model.Application, report *model.AuditReport, p *db.Project) {
+func sloRequestsChart(app *model.Application, report *model.AuditReport, p *db.Project) {
 	hm := report.GetOrCreateHeatmap("Latency & Errors heatmap, requests per second")
 	if hm == nil {
 		return

--- a/constructor/queries.go
+++ b/constructor/queries.go
@@ -110,6 +110,8 @@ var QUERIES = map[string]string{
 	"container_cassandra_queries_histogram": `rate(container_cassandra_queries_duration_seconds_total_bucket[$RANGE])`,
 	"container_rabbitmq_messages":           `rate(container_rabbitmq_messages_total[$RANGE])`,
 	"container_nats_messages":               `rate(container_nats_messages_total[$RANGE])`,
+	"container_dns_requests_total":          `rate(container_dns_requests_total[$RANGE])`,
+	"container_dns_requests_latency":        `rate(container_dns_requests_duration_seconds_total_bucket[$RANGE])`,
 
 	"kube_pod_init_container_info":                     `kube_pod_init_container_info`,
 	"kube_pod_container_resource_requests":             `kube_pod_container_resource_requests`,

--- a/front/src/views/Health.vue
+++ b/front/src/views/Health.vue
@@ -27,6 +27,7 @@
                 { value: 'disk_io', text: 'I/O', sortable: false, align: 'end' },
                 { value: 'disk_usage', text: 'Disk', sortable: false, align: 'end' },
                 { value: 'network', text: 'Net', sortable: false, align: 'end' },
+                { value: 'dns', text: 'DNS', sortable: false, align: 'end' },
                 { value: 'logs', text: 'Logs', sortable: false, align: 'center' },
             ]"
             :footer-props="{ itemsPerPageOptions: [10, 20, 50, 100, -1] }"
@@ -69,6 +70,9 @@
             </template>
             <template #item.network="{ item: { id, network: param } }">
                 <router-link :to="link(id, 'Net')" class="value" :class="param.status">{{ param.value || '–' }}</router-link>
+            </template>
+            <template #item.dns="{ item: { id, dns: param } }">
+                <router-link :to="link(id, 'DNS')" class="value" :class="param.status">{{ param.value || '–' }}</router-link>
             </template>
             <template #item.logs="{ item: { id, logs: param } }">
                 <router-link :to="link(id, 'Logs', { query: JSON.stringify({ source: 'agent', view: 'patterns' }) })" class="logs">

--- a/model/audit_report.go
+++ b/model/audit_report.go
@@ -16,6 +16,7 @@ const (
 	AuditReportMemory      AuditReportName = "Memory"
 	AuditReportStorage     AuditReportName = "Storage"
 	AuditReportNetwork     AuditReportName = "Net"
+	AuditReportDNS         AuditReportName = "DNS"
 	AuditReportLogs        AuditReportName = "Logs"
 	AuditReportPostgres    AuditReportName = "Postgres"
 	AuditReportRedis       AuditReportName = "Redis"

--- a/model/check.go
+++ b/model/check.go
@@ -86,6 +86,9 @@ var Checks = struct {
 	JvmAvailability        CheckConfig
 	JvmSafepointTime       CheckConfig
 	DotNetAvailability     CheckConfig
+	DnsLatency             CheckConfig
+	DnsServerErrors        CheckConfig
+	DnsNxdomainErrors      CheckConfig
 }{
 	index: map[CheckId]*CheckConfig{},
 
@@ -292,6 +295,28 @@ var Checks = struct {
 		DefaultThreshold:        0,
 		MessageTemplate:         `{{.ItemsWithToBe ".NET instance"}} unavailable`,
 		ConditionFormatTemplate: "the number of unavailable .NET instances > <threshold>",
+	},
+	DnsLatency: CheckConfig{
+		Type:                    CheckTypeValueBased,
+		Title:                   "DNS latency",
+		DefaultThreshold:        0.1,
+		Unit:                    CheckUnitSecond,
+		MessageTemplate:         `high latency`,
+		ConditionFormatTemplate: "the 95th percentile of DNS response times > <threshold>",
+	},
+	DnsServerErrors: CheckConfig{
+		Type:                    CheckTypeEventBased,
+		Title:                   "DNS server errors",
+		DefaultThreshold:        0,
+		MessageTemplate:         `{{.Count "server DNS error"}} occurred`,
+		ConditionFormatTemplate: "the number of server DNS errors (excluding NXDOMAIN) > <threshold>",
+	},
+	DnsNxdomainErrors: CheckConfig{
+		Type:                    CheckTypeEventBased,
+		Title:                   "DNS NXDOMAIN errors",
+		DefaultThreshold:        0,
+		MessageTemplate:         `the app received an empty DNS response {{.Count "time"}}`,
+		ConditionFormatTemplate: "the number of the NXDOMAIN DNS errors (for previously valid requests) > <threshold>",
 	},
 }
 

--- a/model/container.go
+++ b/model/container.go
@@ -15,6 +15,11 @@ const (
 	ContainerStatusTerminated ContainerStatus = "terminated"
 )
 
+type DNSRequest struct {
+	Type   string
+	Domain string
+}
+
 type Container struct {
 	Id   string
 	Name string
@@ -46,13 +51,18 @@ type Container struct {
 	MemoryRequest *timeseries.TimeSeries
 
 	OOMKills *timeseries.TimeSeries
+
+	DNSRequests          map[DNSRequest]map[string]*timeseries.TimeSeries
+	DNSRequestsHistogram map[float32]*timeseries.TimeSeries
 }
 
 func NewContainer(id, name string) *Container {
 	return &Container{
-		Id:               id,
-		Name:             name,
-		ApplicationTypes: map[ApplicationType]bool{},
+		Id:                   id,
+		Name:                 name,
+		ApplicationTypes:     map[ApplicationType]bool{},
+		DNSRequests:          map[DNSRequest]map[string]*timeseries.TimeSeries{},
+		DNSRequestsHistogram: map[float32]*timeseries.TimeSeries{},
 	}
 }
 

--- a/model/table.go
+++ b/model/table.go
@@ -40,11 +40,11 @@ func (t *Table) SortRows() {
 	})
 }
 
-func (t *Table) SetSorted(s bool) *Table {
+func (t *Table) SetSorted() *Table {
 	if t == nil {
 		return nil
 	}
-	t.sorted = s
+	t.sorted = true
 	return t
 }
 
@@ -194,6 +194,21 @@ func (c *TableCell) SetMaxWidth(w int) *TableCell {
 		return nil
 	}
 	c.MaxWidth = w
+	return c
+}
+
+func (c *TableCell) SetEventsCount(count uint64) *TableCell {
+	switch {
+	case count < 1:
+	case count > 1e6:
+		c.Value = fmt.Sprintf("%.1f", float32(count)/1e6)
+		c.SetUnit("M")
+	case count > 1e3:
+		c.Value = fmt.Sprintf("%.1f", float32(count)/1e3)
+		c.SetUnit("k")
+	default:
+		c.Value = fmt.Sprintf("%d", count)
+	}
 	return c
 }
 


### PR DESCRIPTION
This PR introduces DNS monitoring capability in Coroot. This feature is based on metrics gathered by [coroot-node-agent](https://github.com/coroot/coroot-node-agent) using eBPF. Coroot has three built-in inspections to highlight the most common DNS issues out-of-the-box:

1. **DNS latency**: This inspection checks the 95th percentile of DNS response time. By default, the threshold is set at 100ms, but you can easily adjust it for a particular app or for the entire project.
2. **DNS server errors**: This check identifies situations when a DNS server responds with an error.
3. **DNS NXDOMAIN errors**: This check highlights scenarios when the application receives no results for certain domains, such as when a Kubernetes headless service has no ready endpoints.




<img width="1177" alt="Screenshot 2024-06-03 at 14 39 43" src="https://github.com/coroot/coroot/assets/194465/d43eef1d-5f39-4cb5-b14c-5499bd6e77a2">

