### PR TITLE
Custom applications

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -211,6 +211,36 @@ func (api *Api) Categories(w http.ResponseWriter, r *http.Request) {
 	utils.WriteJson(w, views.Categories(p))
 }
 
+func (api *Api) CustomApplications(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	projectId := db.ProjectId(vars["project"])
+
+	if r.Method == http.MethodPost {
+		if api.readOnly {
+			return
+		}
+		var form forms.CustomApplicationForm
+		if err := forms.ReadAndValidate(r, &form); err != nil {
+			klog.Warningln("bad request:", err)
+			http.Error(w, "Invalid name or patterns", http.StatusBadRequest)
+			return
+		}
+		if err := api.db.SaveCustomApplication(projectId, form.Name, form.NewName, form.InstancePatterns); err != nil {
+			klog.Errorln("failed to save:", err)
+			http.Error(w, "", http.StatusInternalServerError)
+			return
+		}
+		return
+	}
+	p, err := api.db.GetProject(projectId)
+	if err != nil {
+		klog.Errorln(err)
+		http.Error(w, "", http.StatusInternalServerError)
+		return
+	}
+	utils.WriteJson(w, views.CustomApplications(p))
+}
+
 func (api *Api) Integrations(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	projectId := db.ProjectId(vars["project"])

--- a/api/forms/forms.go
+++ b/api/forms/forms.go
@@ -110,6 +110,25 @@ func (f *ApplicationCategoryForm) Valid() bool {
 	return true
 }
 
+type CustomApplicationForm struct {
+	Name    string `json:"name"`
+	NewName string `json:"new_name"`
+
+	InstancePatternsStr string `json:"instance_patterns"`
+	InstancePatterns    []string
+}
+
+func (f *CustomApplicationForm) Valid() bool {
+	if !slugRe.MatchString(f.NewName) {
+		return false
+	}
+	f.InstancePatterns = strings.Fields(f.InstancePatternsStr)
+	if !utils.GlobValidate(f.InstancePatterns) {
+		return false
+	}
+	return true
+}
+
 type ApplicationInstrumentationForm struct {
 	model.ApplicationInstrumentation
 }

--- a/api/views/application/application.go
+++ b/api/views/application/application.go
@@ -3,6 +3,8 @@ package application
 import (
 	"sort"
 
+	"golang.org/x/exp/maps"
+
 	"github.com/coroot/coroot/model"
 	"github.com/coroot/coroot/timeseries"
 	"github.com/coroot/coroot/utils"
@@ -19,10 +21,13 @@ type AppMap struct {
 
 	Clients      []*Application `json:"clients"`
 	Dependencies []*Application `json:"dependencies"`
+
+	CustomApplications []string `json:"custom_applications"`
 }
 
 type Application struct {
 	Id         model.ApplicationId `json:"id"`
+	Custom     bool                `json:"custom"`
 	Status     model.Status        `json:"status"`
 	Indicators []model.Indicator   `json:"indicators"`
 	Labels     model.Labels        `json:"labels"`
@@ -57,10 +62,12 @@ func Render(world *model.World, app *model.Application) *View {
 	appMap := &AppMap{
 		Application: &Application{
 			Id:         app.Id,
+			Custom:     app.Custom,
 			Status:     app.Status,
 			Indicators: model.CalcIndicators(app),
 			Labels:     app.Labels(),
 		},
+		CustomApplications: maps.Keys(world.CustomApplications),
 	}
 
 	deps := map[model.ApplicationId]bool{}
@@ -169,6 +176,7 @@ func (m *AppMap) addDependency(w *model.World, id model.ApplicationId) {
 	}
 	m.Dependencies = append(m.Dependencies, &Application{
 		Id:         id,
+		Custom:     app.Custom,
 		Status:     app.Status,
 		Indicators: model.CalcIndicators(app),
 		Labels:     app.Labels(),
@@ -187,6 +195,7 @@ func (m *AppMap) addClient(w *model.World, id model.ApplicationId) {
 	}
 	m.Clients = append(m.Clients, &Application{
 		Id:         id,
+		Custom:     app.Custom,
 		Status:     app.Status,
 		Indicators: model.CalcIndicators(app),
 		Labels:     app.Labels(),

--- a/api/views/applications/categories.go
+++ b/api/views/applications/categories.go
@@ -1,4 +1,4 @@
-package categories
+package applications
 
 import (
 	"sort"
@@ -8,7 +8,7 @@ import (
 	"github.com/coroot/coroot/model"
 )
 
-type View struct {
+type CategoriesView struct {
 	Categories   []Category        `json:"categories"`
 	Integrations map[string]string `json:"integrations"`
 }
@@ -22,7 +22,7 @@ type Category struct {
 	NotifyOfDeployments bool                      `json:"notify_of_deployments"`
 }
 
-func Render(p *db.Project) *View {
+func RenderCategories(p *db.Project) *CategoriesView {
 	var categories []Category
 	for c, ps := range model.BuiltinCategoryPatterns {
 		categories = append(categories, Category{
@@ -55,7 +55,7 @@ func Render(p *db.Project) *View {
 
 	categories = append(categories, custom...)
 
-	v := &View{Categories: categories, Integrations: map[string]string{}}
+	v := &CategoriesView{Categories: categories, Integrations: map[string]string{}}
 
 	for _, i := range p.Settings.Integrations.GetInfo() {
 		if i.Configured && i.Deployments {

--- a/api/views/applications/custom_applications.go
+++ b/api/views/applications/custom_applications.go
@@ -1,0 +1,31 @@
+package applications
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/coroot/coroot/db"
+)
+
+type CustomApplicationsView struct {
+	CustomApplications []CustomApplication `json:"custom_applications"`
+}
+
+type CustomApplication struct {
+	Name             string `json:"name"`
+	InstancePatterns string `json:"instance_patterns"`
+}
+
+func RenderCustomApplications(p *db.Project) *CustomApplicationsView {
+	v := &CustomApplicationsView{}
+	for name, app := range p.Settings.CustomApplications {
+		v.CustomApplications = append(v.CustomApplications, CustomApplication{
+			Name:             name,
+			InstancePatterns: strings.Join(app.InstancePattens, " "),
+		})
+	}
+	sort.Slice(v.CustomApplications, func(i, j int) bool {
+		return v.CustomApplications[i].Name < v.CustomApplications[j].Name
+	})
+	return v
+}

--- a/api/views/views.go
+++ b/api/views/views.go
@@ -5,8 +5,8 @@ import (
 	"net/url"
 
 	"github.com/coroot/coroot/api/views/application"
+	"github.com/coroot/coroot/api/views/applications"
 	"github.com/coroot/coroot/api/views/aws"
-	"github.com/coroot/coroot/api/views/categories"
 	"github.com/coroot/coroot/api/views/configs"
 	"github.com/coroot/coroot/api/views/integrations"
 	"github.com/coroot/coroot/api/views/logs"
@@ -43,8 +43,12 @@ func Configs(checkConfigs model.CheckConfigs) *configs.View {
 	return configs.Render(checkConfigs)
 }
 
-func Categories(p *db.Project) *categories.View {
-	return categories.Render(p)
+func Categories(p *db.Project) *applications.CategoriesView {
+	return applications.RenderCategories(p)
+}
+
+func CustomApplications(p *db.Project) *applications.CustomApplicationsView {
+	return applications.RenderCustomApplications(p)
 }
 
 func Integrations(p *db.Project) *integrations.View {

--- a/constructor/constructor.go
+++ b/constructor/constructor.go
@@ -72,6 +72,7 @@ func (p *Profile) stage(name string, f func()) {
 func (c *Constructor) LoadWorld(ctx context.Context, from, to timeseries.Time, step timeseries.Duration, prof *Profile) (*model.World, error) {
 	start := time.Now()
 	w := model.NewWorld(from, to, step)
+	w.CustomApplications = c.project.Settings.CustomApplications
 
 	if prof == nil {
 		prof = &Profile{}
@@ -115,7 +116,7 @@ func (c *Constructor) LoadWorld(ctx context.Context, from, to timeseries.Time, s
 	prof.stage("load_rds", func() { c.loadRds(w, metrics, pjs, rdsInstancesById) })
 	prof.stage("load_elasticache", func() { c.loadElasticache(w, metrics, pjs, ecInstancesById) })
 	prof.stage("load_fargate_containers", func() { loadFargateContainers(w, metrics, pjs) })
-	prof.stage("load_containers", func() { loadContainers(w, metrics, pjs, nodesByID, servicesByClusterIP, ip2fqdn) })
+	prof.stage("load_containers", func() { c.loadContainers(w, metrics, pjs, nodesByID, servicesByClusterIP, ip2fqdn) })
 	prof.stage("enrich_instances", func() { enrichInstances(w, metrics, rdsInstancesById, ecInstancesById) })
 	prof.stage("join_db_cluster", func() { joinDBClusterComponents(w) })
 	prof.stage("calc_app_categories", func() { c.calcApplicationCategories(w) })

--- a/constructor/containers.go
+++ b/constructor/containers.go
@@ -19,7 +19,7 @@ type instanceId struct {
 	node model.NodeId
 }
 
-func getInstanceAndContainer(w *model.World, node *model.Node, instances map[instanceId]*model.Instance, containerId string) (*model.Instance, *model.Container) {
+func (c *Constructor) getInstanceAndContainer(w *model.World, node *model.Node, instances map[instanceId]*model.Instance, containerId string) (*model.Instance, *model.Container) {
 	var nodeId model.NodeId
 	var nodeName string
 	if node != nil {
@@ -38,45 +38,55 @@ func getInstanceAndContainer(w *model.World, node *model.Node, instances map[ins
 		ns, pod := parts[2], parts[3]
 		containerName = parts[4]
 		instance = instances[instanceId{ns: ns, name: pod, node: nodeId}]
-	} else if len(parts) == 7 && parts[1] == "nomad" {
+		if instance == nil {
+			return nil, nil
+		}
+		return instance, instance.GetOrCreateContainer(containerId, containerName)
+	}
+
+	var (
+		id    instanceId
+		appId model.ApplicationId
+	)
+	if len(parts) == 7 && parts[1] == "nomad" {
 		ns, job, group, allocId, task := parts[2], parts[3], parts[4], parts[5], parts[6]
 		containerName = task
-		appId := model.NewApplicationId(ns, model.ApplicationKindNomadJobGroup, job+"."+group)
-		id := instanceId{ns: ns, name: group + "-" + allocId, node: nodeId}
-		instance = instances[id]
-		if instance == nil {
-			instance = w.GetOrCreateApplication(appId).GetOrCreateInstance(id.name, node)
-			instances[id] = instance
-		}
+		appId = model.NewApplicationId(ns, model.ApplicationKindNomadJobGroup, job+"."+group)
+		id = instanceId{ns: ns, name: group + "-" + allocId, node: nodeId}
 	} else {
-		var appId model.ApplicationId
-		var instanceName, ns string
 		if len(parts) == 5 && parts[1] == "swarm" {
-			ns = parts[2]
-			appId = model.NewApplicationId(ns, model.ApplicationKindDockerSwarmService, parts[3])
+			id.ns = parts[2]
+			appId = model.NewApplicationId(id.ns, model.ApplicationKindDockerSwarmService, parts[3])
 			containerName = parts[3]
-			instanceName = parts[3] + "." + parts[4]
+			id.name = parts[3] + "." + parts[4]
 		} else {
 			containerName = strings.TrimSuffix(
 				strings.TrimSuffix(parts[len(parts)-1], ".service"),
 				".slice")
+			id.name = fmt.Sprintf("%s@%s", containerName, nodeName)
 			appId = model.NewApplicationId("", model.ApplicationKindUnknown, containerName)
-			instanceName = fmt.Sprintf("%s@%s", containerName, nodeName)
-		}
-		id := instanceId{ns: ns, name: instanceName, node: nodeId}
-		instance = instances[id]
-		if instance == nil {
-			instance = w.GetOrCreateApplication(appId).GetOrCreateInstance(instanceName, node)
-			instances[id] = instance
 		}
 	}
-	if instance == nil {
+	if id.name == "" {
 		return nil, nil
+	}
+	if id.ns == "" {
+		id.ns = "_"
+	}
+	id.node = nodeId
+	instance = instances[id]
+	if instance == nil {
+		customApp := c.project.GetCustomApplicationName(id.name)
+		if customApp != "" {
+			appId.Name = customApp
+		}
+		instance = w.GetOrCreateApplication(appId, customApp != "").GetOrCreateInstance(id.name, node)
+		instances[id] = instance
 	}
 	return instance, instance.GetOrCreateContainer(containerId, containerName)
 }
 
-func loadContainers(w *model.World, metrics map[string][]model.MetricValues, pjs promJobStatuses, nodesByID map[model.NodeId]*model.Node, servicesByClusterIP map[string]*model.Service, ip2fqdn map[string]*utils.StringSet) {
+func (c *Constructor) loadContainers(w *model.World, metrics map[string][]model.MetricValues, pjs promJobStatuses, nodesByID map[model.NodeId]*model.Node, servicesByClusterIP map[string]*model.Service, ip2fqdn map[string]*utils.StringSet) {
 	instances := map[instanceId]*model.Instance{}
 	for _, a := range w.Applications {
 		for _, i := range a.Instances {
@@ -98,7 +108,7 @@ func loadContainers(w *model.World, metrics map[string][]model.MetricValues, pjs
 		}
 		for _, m := range metrics[queryName] {
 			nodeId := model.NewNodeIdFromLabels(m.Labels)
-			instance, container := getInstanceAndContainer(w, nodesByID[nodeId], instances, m.Labels["container_id"])
+			instance, container := c.getInstanceAndContainer(w, nodesByID[nodeId], instances, m.Labels["container_id"])
 			if instance == nil || container == nil {
 				continue
 			}
@@ -301,6 +311,7 @@ func loadContainers(w *model.World, metrics map[string][]model.MetricValues, pjs
 				}
 				appId := model.NewApplicationId("", model.ApplicationKindExternalService, "")
 				svc := getServiceForConnection(u, servicesByClusterIP, servicesByActualDestIP)
+				instanceName := u.ActualRemoteIP + ":" + u.ActualRemotePort
 				if svc != nil {
 					u.Service = svc
 					if id, ok := svc.GetDestinationApplicationId(); ok {
@@ -318,7 +329,11 @@ func loadContainers(w *model.World, metrics map[string][]model.MetricValues, pjs
 						appId.Name = externalServiceName(u.ActualRemotePort)
 					}
 				}
-				ri := w.GetOrCreateApplication(appId).GetOrCreateInstance(u.ActualRemoteIP+":"+u.ActualRemotePort, nil)
+				customApp := c.project.GetCustomApplicationName(instanceName)
+				if customApp != "" {
+					appId.Name = customApp
+				}
+				ri := w.GetOrCreateApplication(appId, customApp != "").GetOrCreateInstance(instanceName, nil)
 				ri.TcpListens[model.Listen{IP: u.ActualRemoteIP, Port: u.ActualRemotePort}] = true
 				u.RemoteInstance = ri
 			}

--- a/constructor/elasticache.go
+++ b/constructor/elasticache.go
@@ -22,7 +22,7 @@ func loadElasticacheMetadata(w *model.World, metrics map[string][]model.MetricVa
 			}
 			appId = model.NewApplicationId("", model.ApplicationKindElasticacheCluster, m.Labels["cluster_id"])
 			instanceName := instanceParts[1] + "-" + instanceParts[2]
-			instance = w.GetOrCreateApplication(appId).GetOrCreateInstance(instanceName, nil)
+			instance = w.GetOrCreateApplication(appId, false).GetOrCreateInstance(instanceName, nil)
 			ecInstancesById[ecId] = instance
 			instance.Elasticache = &model.Elasticache{}
 		}

--- a/constructor/k8s.go
+++ b/constructor/k8s.go
@@ -113,7 +113,7 @@ func podInfo(w *model.World, metrics []model.MetricValues) map[string]*model.Ins
 		podOwners[podId{name: pod, ns: ns}] = appId
 		instance := pods[uid]
 		if instance == nil {
-			instance = w.GetOrCreateApplication(appId).GetOrCreateInstance(pod, node)
+			instance = w.GetOrCreateApplication(appId, false).GetOrCreateInstance(pod, node)
 			if instance.Pod == nil {
 				instance.Pod = &model.Pod{}
 			}

--- a/constructor/rds.go
+++ b/constructor/rds.go
@@ -25,7 +25,7 @@ func loadRdsMetadata(w *model.World, metrics map[string][]model.MetricValues, pj
 			} else {
 				id = model.NewApplicationId("", model.ApplicationKindRds, instanceParts[1])
 			}
-			instance = w.GetOrCreateApplication(id).GetOrCreateInstance(instanceParts[1], nil)
+			instance = w.GetOrCreateApplication(id, false).GetOrCreateInstance(instanceParts[1], nil)
 			rdsInstancesById[rdsId] = instance
 			instance.Rds = &model.Rds{}
 		}

--- a/front/src/api.js
+++ b/front/src/api.js
@@ -122,6 +122,14 @@ export default class Api {
         this.post(this.projectPath(`categories`), form, cb);
     }
 
+    getCustomApplications(cb) {
+        this.get(this.projectPath(`custom_applications`), {}, cb);
+    }
+
+    saveCustomApplication(form, cb) {
+        this.post(this.projectPath(`custom_applications`), form, cb);
+    }
+
     getIntegrations(type, cb) {
         this.get(this.projectPath(`integrations${type ? '/' + type : ''}`), {}, cb);
     }

--- a/front/src/components/AppMap.vue
+++ b/front/src/components/AppMap.vue
@@ -39,6 +39,21 @@
                 <div>
                     <span class="name">
                         <AppHealth :app="map.application" />
+
+                        <v-btn
+                            v-if="map.application.custom"
+                            icon
+                            x-small
+                            :to="{
+                                name: 'project_settings',
+                                params: { tab: 'applications' },
+                                hash: '#custom-applications',
+                                query: { custom_app: $utils.appId(map.application.id).name },
+                            }"
+                            class="ml-1"
+                        >
+                            <v-icon small>mdi-cog-outline</v-icon>
+                        </v-btn>
                     </span>
                     <Labels :labels="map.application.labels" class="d-none d-sm-block label" />
                 </div>
@@ -66,6 +81,47 @@
                                 <v-icon v-if="i.labels && i.labels['proxy']" small color="grey" style="margin-bottom: 2px"
                                     >mdi-swap-horizontal</v-icon
                                 >
+                                <template
+                                    v-if="!map.application.custom && ['Unknown', 'ExternalService'].includes($utils.appId(map.application.id).kind)"
+                                >
+                                    <v-menu offset-y>
+                                        <template v-slot:activator="{ attrs, on }">
+                                            <v-btn icon x-small class="ml-1" v-bind="attrs" v-on="on">
+                                                <v-icon small>mdi-dots-vertical</v-icon>
+                                            </v-btn>
+                                        </template>
+
+                                        <v-list dense>
+                                            <v-list-item class="grey--text">Move the instance to another application</v-list-item>
+                                            <v-list-item
+                                                link
+                                                :to="{
+                                                    name: 'project_settings',
+                                                    params: { tab: 'applications' },
+                                                    hash: '#custom-applications',
+                                                    query: { custom_app: '', instance_pattern: i.id },
+                                                }"
+                                            >
+                                                <v-list-item-title> <v-icon small class="mr-2">mdi-plus</v-icon>a new application</v-list-item-title>
+                                            </v-list-item>
+                                            <template v-if="map.custom_applications">
+                                                <v-list-item
+                                                    v-for="a in map.custom_applications"
+                                                    link
+                                                    :to="{
+                                                        name: 'project_settings',
+                                                        params: { tab: 'applications' },
+                                                        hash: '#custom-applications',
+                                                        query: { custom_app: a, instance_pattern: i.id },
+                                                    }"
+                                                >
+                                                    <v-icon small class="mr-2">mdi-arrow-right-thin</v-icon>
+                                                    <v-list-item-title>{{ a }}</v-list-item-title>
+                                                </v-list-item>
+                                            </template>
+                                        </v-list>
+                                    </v-menu>
+                                </template>
                             </div>
                         </div>
                         <Labels :labels="i.labels" class="d-none d-sm-block" />

--- a/front/src/components/ApplicationFilter.vue
+++ b/front/src/components/ApplicationFilter.vue
@@ -102,7 +102,7 @@ export default {
         autoSelectNamespaceThreshold: Number,
         configureTo: {
             type: Object,
-            default: () => ({ name: 'project_settings', params: { tab: 'categories' } }),
+            default: () => ({ name: 'project_settings', params: { tab: 'applications' } }),
         },
     },
 

--- a/front/src/views/CustomApplications.vue
+++ b/front/src/views/CustomApplications.vue
@@ -1,0 +1,183 @@
+<template>
+    <div>
+        <v-simple-table>
+            <thead>
+                <tr>
+                    <th>Application name</th>
+                    <th>Instance patterns</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr v-for="app in applications">
+                    <td class="text-no-wrap">
+                        <div class="text-no-wrap">{{ app.name }}</div>
+                    </td>
+                    <td style="line-height: 2em">
+                        <template v-for="p in app.instance_patterns.split(' ').filter((p) => !!p)">
+                            <span class="pattern">{{ p }}</span>
+                            &nbsp;
+                        </template>
+                    </td>
+                    <td>
+                        <div class="d-flex">
+                            <v-btn icon small @click="openForm(app)"><v-icon small>mdi-pencil</v-icon></v-btn>
+                            <v-btn icon small @click="openForm(app, true)"><v-icon small>mdi-trash-can-outline</v-icon></v-btn>
+                        </div>
+                    </td>
+                </tr>
+            </tbody>
+        </v-simple-table>
+
+        <v-btn color="primary" class="mt-2" @click="openForm()">Add an application</v-btn>
+
+        <v-dialog v-model="form.active" max-width="800">
+            <v-card class="pa-4">
+                <div class="d-flex align-center font-weight-medium mb-4">
+                    <div v-if="form.new">Add a new custom application</div>
+                    <div v-else-if="form.del">Delete the "{{ form.name }}" application</div>
+                    <div v-else>Edit the "{{ form.name }}" application</div>
+                    <v-spacer />
+                    <v-btn icon @click="form.active = false"><v-icon>mdi-close</v-icon></v-btn>
+                </div>
+
+                <v-form v-model="form.valid" ref="form">
+                    <div class="subtitle-1">Name</div>
+                    <v-text-field v-model="form.name" outlined dense :disabled="form.del" :rules="[$validators.isSlug]" />
+
+                    <template>
+                        <div class="subtitle-1">Instance patterns</div>
+                        <div class="caption">
+                            space-delimited list of
+                            <a href="https://en.wikipedia.org/wiki/Glob_(programming)" target="_blank">glob patterns</a>
+                            for <var>instance_name</var>, e.g.: <var>mysql@node1 cassandra@cass-node*</var>
+                        </div>
+                        <v-textarea v-model="form.instance_patterns" outlined dense rows="1" auto-grow :disabled="form.del" />
+                    </template>
+
+                    <v-alert v-if="error" color="red" icon="mdi-alert-octagon-outline" outlined text>
+                        {{ error }}
+                    </v-alert>
+                    <v-alert v-if="message" color="green" outlined text>
+                        {{ message }}
+                    </v-alert>
+                    <div class="d-flex align-center">
+                        <v-spacer />
+                        <v-btn v-if="form.del" color="error" :loading="saving" @click="save">Delete</v-btn>
+                        <v-btn v-else color="primary" :disabled="!form.valid" :loading="saving" @click="save">Save</v-btn>
+                    </div>
+                </v-form>
+            </v-card>
+        </v-dialog>
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        projectId: String,
+    },
+
+    data() {
+        return {
+            applications: [],
+            loading: false,
+            error: '',
+            message: '',
+            form: {
+                active: false,
+                new: false,
+                del: false,
+                oldName: '',
+                name: '',
+                instance_patterns: '',
+                valid: true,
+            },
+            saving: false,
+        };
+    },
+
+    mounted() {
+        this.get();
+    },
+
+    watch: {
+        projectId() {
+            this.get();
+        },
+    },
+
+    methods: {
+        get() {
+            this.loading = true;
+            this.error = '';
+            this.$api.getCustomApplications((data, error) => {
+                this.loading = false;
+                if (error) {
+                    this.error = error;
+                    return;
+                }
+                this.applications = data.custom_applications;
+
+                const app = this.applications ? this.applications.find((a) => a.name === this.$route.query.custom_app) || {} : {};
+                const p = this.$route.query.instance_pattern;
+                if (!app.name && !p) {
+                    return;
+                }
+                if (p) {
+                    if (!app.instance_patterns) {
+                        app.instance_patterns = p;
+                    } else {
+                        app.instance_patterns += ' ' + p;
+                    }
+                }
+                this.openForm(app);
+                this.$router.replace({ query: { ...this.$route.query, custom_app: undefined, instance_pattern: undefined }, hash: this.$route.hash });
+            });
+        },
+        openForm(application, del) {
+            this.error = '';
+            this.form.active = true;
+            this.form.new = !application || !application.name;
+            this.form.del = del;
+            this.form.oldName = application ? application.name : '';
+            this.form.name = application ? application.name : '';
+            this.form.instance_patterns = application ? application.instance_patterns : '';
+            this.$refs.form && this.$refs.form.resetValidation();
+        },
+        save() {
+            this.saving = true;
+            this.error = '';
+            this.message = '';
+            const patterns = this.form.del ? '' : this.form.instance_patterns;
+            const form = {
+                name: this.form.oldName,
+                new_name: this.form.name,
+                instance_patterns: patterns,
+            };
+            this.$api.saveCustomApplication(form, (data, error) => {
+                this.saving = false;
+                if (error) {
+                    this.error = error;
+                    return;
+                }
+                this.message = 'Settings were successfully updated.';
+                setTimeout(() => {
+                    this.message = '';
+                    this.form.active = false;
+                }, 1000);
+                this.get();
+            });
+        },
+    },
+};
+</script>
+
+<style scoped>
+.pattern {
+    border: 1px solid #bdbdbd;
+    border-radius: 4px;
+    padding: 2px 4px;
+    white-space: nowrap;
+}
+</style>

--- a/front/src/views/Project.vue
+++ b/front/src/views/Project.vue
@@ -57,8 +57,8 @@
             <ProjectCheckConfigs :projectId="projectId" />
         </template>
 
-        <template v-if="tab === 'categories'">
-            <h1 class="text-h5 my-5">
+        <template v-if="tab === 'applications'">
+            <h2 class="text-h5 my-5" id="categories">
                 Application categories
                 <a
                     href="https://coroot.com/docs/coroot-community-edition/getting-started/project-configuration#application-categories"
@@ -66,13 +66,35 @@
                 >
                     <v-icon>mdi-information-outline</v-icon>
                 </a>
-            </h1>
+            </h2>
             <p>
                 You can organize your applications into groups by defining
                 <a href="https://en.wikipedia.org/wiki/Glob_(programming)" target="_blank">glob patterns</a>
                 in the <var>&lt;namespace&gt;/&lt;application_name&gt;</var> format.
             </p>
             <ApplicationCategories />
+
+            <h2 class="text-h5 mt-10 mb-5" id="custom-applications">Custom applications</h2>
+
+            <p>Coroot groups individual containers into applications using the following approach:</p>
+
+            <ul>
+                <li><b>Kubernetes metadata</b>: Pods are grouped into Deployments, StatefulSets, etc.</li>
+                <li>
+                    <b>Non-Kubernetes containers</b>: Containers such as Docker containers or Systemd units are grouped into applications by their
+                    names. For example, Systemd services named <var>mysql</var> on different hosts are grouped into a single application called
+                    <var>mysql</var>.
+                </li>
+            </ul>
+
+            <p class="my-5">
+                This default approach works well in most cases. However, since no one knows your system better than you do, Coroot allows you to
+                manually adjust application groupings to better fit your specific needs. You can match desired application instances by defining
+                <a href="https://en.wikipedia.org/wiki/Glob_(programming)" target="_blank">glob patterns</a>
+                for <var>instance_name</var>. Note that this is not applicable to Kubernetes applications.
+            </p>
+
+            <CustomApplications />
         </template>
 
         <template v-if="tab === 'notifications'">
@@ -97,6 +119,7 @@ import Integrations from './Integrations.vue';
 import IntegrationPrometheus from './IntegrationPrometheus.vue';
 import IntegrationClickhouse from './IntegrationClickhouse.vue';
 import IntegrationAWS from './IntegrationAWS.vue';
+import CustomApplications from '@/views/CustomApplications.vue';
 
 const tabs = [
     { id: undefined, name: 'General' },
@@ -104,7 +127,7 @@ const tabs = [
     { id: 'clickhouse', name: 'Clickhouse' },
     { id: 'aws', name: 'AWS' },
     { id: 'inspections', name: 'Inspections' },
-    { id: 'categories', name: 'Categories' },
+    { id: 'applications', name: 'Applications' },
     { id: 'notifications', name: 'Notifications' },
 ];
 
@@ -115,6 +138,7 @@ export default {
     },
 
     components: {
+        CustomApplications,
         IntegrationPrometheus,
         IntegrationClickhouse,
         IntegrationAWS,

--- a/main.go
+++ b/main.go
@@ -142,6 +142,7 @@ func main() {
 	r.HandleFunc("/api/project/{project}/overview/{view}", a.Overview).Methods(http.MethodGet)
 	r.HandleFunc("/api/project/{project}/configs", a.Configs).Methods(http.MethodGet)
 	r.HandleFunc("/api/project/{project}/categories", a.Categories).Methods(http.MethodGet, http.MethodPost)
+	r.HandleFunc("/api/project/{project}/custom_applications", a.CustomApplications).Methods(http.MethodGet, http.MethodPost)
 	r.HandleFunc("/api/project/{project}/integrations", a.Integrations).Methods(http.MethodGet, http.MethodPut)
 	r.HandleFunc("/api/project/{project}/integrations/{type}", a.Integration).Methods(http.MethodGet, http.MethodPut, http.MethodDelete, http.MethodPost)
 	r.HandleFunc("/api/project/{project}/app/{app}", a.App).Methods(http.MethodGet)

--- a/model/application.go
+++ b/model/application.go
@@ -12,6 +12,7 @@ import (
 type Application struct {
 	Id ApplicationId
 
+	Custom   bool
 	Category ApplicationCategory
 
 	Instances   []*Instance

--- a/model/custom_application.go
+++ b/model/custom_application.go
@@ -1,0 +1,5 @@
+package model
+
+type CustomApplication struct {
+	InstancePattens []string `json:"instance_pattens"`
+}

--- a/model/world.go
+++ b/model/world.go
@@ -17,7 +17,8 @@ type IntegrationStatus struct {
 type World struct {
 	Ctx timeseries.Context
 
-	CheckConfigs CheckConfigs
+	CustomApplications map[string]CustomApplication
+	CheckConfigs       CheckConfigs
 
 	Nodes           []*Node
 	Applications    map[ApplicationId]*Application
@@ -35,9 +36,10 @@ type nsAndName struct {
 
 func NewWorld(from, to timeseries.Time, step timeseries.Duration) *World {
 	return &World{
-		Ctx:          timeseries.Context{From: from, To: to, Step: step},
-		Applications: map[ApplicationId]*Application{},
-		AWS:          AWS{DiscoveryErrors: map[string]bool{}},
+		Ctx:                timeseries.Context{From: from, To: to, Step: step},
+		Applications:       map[ApplicationId]*Application{},
+		AWS:                AWS{DiscoveryErrors: map[string]bool{}},
+		CustomApplications: map[string]CustomApplication{},
 	}
 }
 
@@ -55,10 +57,11 @@ func (w *World) GetApplicationByNsAndName(ns, name string) *Application {
 	return w.appsByNsAndName[nsAndName{ns: ns, name: name}]
 }
 
-func (w *World) GetOrCreateApplication(id ApplicationId) *Application {
+func (w *World) GetOrCreateApplication(id ApplicationId, custom bool) *Application {
 	app := w.GetApplication(id)
 	if app == nil {
 		app = NewApplication(id)
+		app.Custom = custom
 		w.Applications[id] = app
 	}
 	return app


### PR DESCRIPTION
This PR introduces custom applications in Coroot. You can now create applications manually and associate specific instances with them. This is useful when the built-in grouping doesn't accurately reflect your system.

<img width="1196" alt="Screenshot 2024-07-17 at 13 58 10" src="https://github.com/user-attachments/assets/c392f29a-bdb1-449c-8876-0bd20276743d">

For example, if you have 10 Apache HTTPD instances running on 10 nodes as systemd services, Coroot typically groups them into one application by their unit name. If this grouping isn't accurate for your setup, you can create custom applications and define the instance mapping to better match your system design.

<img width="820" alt="Screenshot 2024-07-17 at 14 08 02" src="https://github.com/user-attachments/assets/039c720e-9ba0-4119-8913-0e8909c5eeaf">

