### PR TITLE
using I/O load instead of utilization percentage for highlighting I/O issues

### DIFF
--- a/api/views/configs/configs.go
+++ b/api/views/configs/configs.go
@@ -34,7 +34,7 @@ func Render(configs model.CheckConfigs) *View {
 	v.addReport(model.AuditReportDeployments, cs.DeploymentStatus)
 	v.addReport(model.AuditReportCPU, cs.CPUNode, cs.CPUContainer)
 	v.addReport(model.AuditReportMemory, cs.MemoryOOM, cs.MemoryLeakPercent)
-	v.addReport(model.AuditReportStorage, cs.StorageIO, cs.StorageSpace)
+	v.addReport(model.AuditReportStorage, cs.StorageIOLoad, cs.StorageSpace)
 	v.addReport(model.AuditReportNetwork, cs.NetworkRTT)
 	v.addReport(model.AuditReportLogs, cs.LogErrors)
 	v.addReport(model.AuditReportPostgres, cs.PostgresAvailability, cs.PostgresLatency, cs.PostgresErrors, cs.PostgresReplicationLag, cs.PostgresConnections)

--- a/api/views/overview/health.go
+++ b/api/views/overview/health.go
@@ -19,18 +19,18 @@ type ApplicationStatus struct {
 	Status   model.Status              `json:"status"`
 	Type     *ApplicationType          `json:"type"`
 
-	Errors    ApplicationParam `json:"errors"`
-	Latency   ApplicationParam `json:"latency"`
-	Upstreams ApplicationParam `json:"upstreams"`
-	Instances ApplicationParam `json:"instances"`
-	Restarts  ApplicationParam `json:"restarts"`
-	CPU       ApplicationParam `json:"cpu"`
-	Memory    ApplicationParam `json:"memory"`
-	DiskIO    ApplicationParam `json:"disk_io"`
-	DiskUsage ApplicationParam `json:"disk_usage"`
-	Network   ApplicationParam `json:"network"`
-	DNS       ApplicationParam `json:"dns"`
-	Logs      ApplicationParam `json:"logs"`
+	Errors     ApplicationParam `json:"errors"`
+	Latency    ApplicationParam `json:"latency"`
+	Upstreams  ApplicationParam `json:"upstreams"`
+	Instances  ApplicationParam `json:"instances"`
+	Restarts   ApplicationParam `json:"restarts"`
+	CPU        ApplicationParam `json:"cpu"`
+	Memory     ApplicationParam `json:"memory"`
+	DiskIOLoad ApplicationParam `json:"disk_io_load"`
+	DiskUsage  ApplicationParam `json:"disk_usage"`
+	Network    ApplicationParam `json:"network"`
+	DNS        ApplicationParam `json:"dns"`
+	Logs       ApplicationParam `json:"logs"`
 }
 
 type ApplicationType struct {
@@ -122,15 +122,12 @@ func renderHealth(w *model.World) []*ApplicationStatus {
 						a.Memory.Status = model.WARNING
 						a.Memory.Value = "leak"
 					}
-				case model.Checks.StorageIO.Id:
+				case model.Checks.StorageIOLoad.Id:
 					if ch.Status != model.UNKNOWN {
-						a.DiskIO.Status = ch.Status
-						if !sloIsViolating {
-							a.DiskIO.Status = model.OK
-						}
+						a.DiskIOLoad.Status = ch.Status
 					}
 					if ch.Value() > 0 {
-						a.DiskIO.Value = formatPercent(ch.Value())
+						a.DiskIOLoad.Value = utils.FormatFloat(ch.Value())
 					}
 				case model.Checks.StorageSpace.Id:
 					a.DiskUsage.Status = ch.Status

--- a/front/src/components/CheckConfigForm.vue
+++ b/front/src/components/CheckConfigForm.vue
@@ -97,6 +97,8 @@ export default {
                     return '%';
                 case 'second':
                     return 'seconds';
+                case 'seconds/second':
+                    return 'seconds/second';
             }
             return '';
         },

--- a/front/src/components/CheckDetails.vue
+++ b/front/src/components/CheckDetails.vue
@@ -42,6 +42,8 @@ export default {
                     return this.check.threshold + '%';
                 case 'second':
                     return this.$format.duration(this.check.threshold * 1000, 'ms');
+                case 'seconds/second':
+                    return this.check.threshold + ' seconds/second';
             }
             return this.check.threshold;
         },

--- a/front/src/views/Health.vue
+++ b/front/src/views/Health.vue
@@ -25,7 +25,7 @@
                 { value: 'restarts', text: 'Restarts', sortable: false, align: 'end' },
                 { value: 'cpu', text: 'CPU', sortable: false, align: 'end' },
                 { value: 'memory', text: 'Mem', sortable: false, align: 'end' },
-                { value: 'disk_io', text: 'I/O', sortable: false, align: 'end' },
+                { value: 'disk_io_load', text: 'I/O load', sortable: false, align: 'end' },
                 { value: 'disk_usage', text: 'Disk', sortable: false, align: 'end' },
                 { value: 'network', text: 'Net', sortable: false, align: 'end' },
                 { value: 'dns', text: 'DNS', sortable: false, align: 'end' },
@@ -81,7 +81,7 @@
             <template #item.memory="{ item: { id, memory: param } }">
                 <router-link :to="link(id, 'Memory')" class="value" :class="param.status">{{ param.value || '–' }}</router-link>
             </template>
-            <template #item.disk_io="{ item: { id, disk_io: param } }">
+            <template #item.disk_io_load="{ item: { id, disk_io_load: param } }">
                 <router-link :to="link(id, 'Storage')" class="value" :class="param.status">{{ param.value || '–' }}</router-link>
             </template>
             <template #item.disk_usage="{ item: { id, disk_usage: param } }">

--- a/model/check.go
+++ b/model/check.go
@@ -27,15 +27,18 @@ const (
 type CheckUnit string
 
 const (
-	CheckUnitPercent = "percent"
-	CheckUnitSecond  = "second"
-	CheckUnitByte    = "byte"
+	CheckUnitPercent          = "percent"
+	CheckUnitSecond           = "second"
+	CheckUnitByte             = "byte"
+	CheckUnitSecondsPerSecond = "seconds/second"
 )
 
 func (u CheckUnit) FormatValue(v float32) string {
 	switch u {
 	case CheckUnitSecond:
 		return utils.FormatDuration(timeseries.Duration(v), 1)
+	case CheckUnitSecondsPerSecond:
+		return utils.FormatDuration(timeseries.Duration(v), 1) + "/second"
 	case CheckUnitByte:
 		value, unit := utils.FormatBytes(v)
 		return value + unit
@@ -66,7 +69,7 @@ var Checks = struct {
 	MemoryOOM              CheckConfig
 	MemoryLeakPercent      CheckConfig
 	StorageSpace           CheckConfig
-	StorageIO              CheckConfig
+	StorageIOLoad          CheckConfig
 	NetworkRTT             CheckConfig
 	NetworkConnectivity    CheckConfig
 	NetworkTCPConnections  CheckConfig
@@ -144,13 +147,13 @@ var Checks = struct {
 		MessageTemplate:         `memory usage is growing by {{.Value}} %% per hour`,
 		ConditionFormatTemplate: "memory usage is growing by > <threshold> % per hour",
 	},
-	StorageIO: CheckConfig{
+	StorageIOLoad: CheckConfig{
 		Type:                    CheckTypeItemBased,
-		Title:                   "Disk I/O",
-		DefaultThreshold:        80,
-		Unit:                    CheckUnitPercent,
-		MessageTemplate:         `high I/O utilization of {{.Items "volume"}}`,
-		ConditionFormatTemplate: "the I/O utilization of a volume > <threshold>",
+		Title:                   "Disk I/O load",
+		DefaultThreshold:        5,
+		Unit:                    CheckUnitSecondsPerSecond,
+		MessageTemplate:         `high I/O load of {{.Items "volume"}}`,
+		ConditionFormatTemplate: "the I/O load of a volume > <threshold>",
 	},
 	StorageSpace: CheckConfig{
 		Type:                    CheckTypeItemBased,


### PR DESCRIPTION
Coroot now uses the I/O load metric (total I/O latency) to identify storage performance issues. Previously, we relied on I/O utilization, which measures the time the disk performs at least one query. This method was accurate for spinning HDDs but is less effective for modern SSDs, which can handle multiple queries simultaneously.

To address this, Coroot sets a default threshold of 5 seconds/second for I/O load. If a disk performs more than 5 I/O requests in parallel, it is flagged as having high I/O load. This threshold is optimal for most average SSDs on the market. However, if you use higher-performance storage, you can easily adjust this threshold for specific applications, databases, or entire projects.

<img width="1183" alt="Screenshot 2024-07-18 at 13 44 51" src="https://github.com/user-attachments/assets/75d7607c-99b0-4de1-9494-43a12a9bf675">

