### PR TITLE
App categories improvements

### DIFF
--- a/model/application_category.go
+++ b/model/application_category.go
@@ -58,6 +58,13 @@ var BuiltinCategoryPatterns = map[ApplicationCategory][]string{
 		"vault/*",
 		"keda/*",
 		"keycloak/*",
+		"longhorn-system/*",
+		"calico-system/*",
+		"_/esm-cache",
+		"_/*motd*",
+		"_/*apt*",
+		"_/*fwupd*",
+		"_/snap*",
 	},
 	ApplicationCategoryMonitoring: {
 		"monitoring/*",


### PR DESCRIPTION
1. Use client's app category instead of the default `application` category
2. Add patterns to improve matching of auxiliary apps to the `control-plane` category