### PR TITLE
Service-to-service traffic

### DIFF
--- a/constructor/containers.go
+++ b/constructor/containers.go
@@ -136,6 +136,14 @@ func (c *Constructor) loadContainers(w *model.World, metrics map[string][]model.
 				if c := getOrCreateConnection(instance, container.Name, m, connectionCache, servicesByClusterIP, servicesByActualDestIP); c != nil {
 					c.ConnectionTime = merge(c.ConnectionTime, m.Values, timeseries.Any)
 				}
+			case "container_net_tcp_bytes_sent":
+				if c := getOrCreateConnection(instance, container.Name, m, connectionCache, servicesByClusterIP, servicesByActualDestIP); c != nil {
+					c.BytesSent = merge(c.BytesSent, m.Values, timeseries.Any)
+				}
+			case "container_net_tcp_bytes_received":
+				if c := getOrCreateConnection(instance, container.Name, m, connectionCache, servicesByClusterIP, servicesByActualDestIP); c != nil {
+					c.BytesReceived = merge(c.BytesReceived, m.Values, timeseries.Any)
+				}
 			case "container_net_tcp_failed_connects":
 				if c := getOrCreateConnection(instance, container.Name, m, connectionCache, servicesByClusterIP, servicesByActualDestIP); c != nil {
 					c.FailedConnections = merge(c.FailedConnections, m.Values, timeseries.Any)

--- a/constructor/queries.go
+++ b/constructor/queries.go
@@ -69,6 +69,8 @@ var QUERIES = map[string]string{
 	"container_net_tcp_failed_connects":         `rate(container_net_tcp_failed_connects_total[$RANGE])`,
 	"container_net_tcp_active_connections":      `container_net_tcp_active_connections`,
 	"container_net_tcp_connection_time_seconds": `rate(container_net_tcp_connection_time_seconds_total[$RANGE])`,
+	"container_net_tcp_bytes_sent":              `rate(container_net_tcp_bytes_sent_total[$RANGE])`,
+	"container_net_tcp_bytes_received":          `rate(container_net_tcp_bytes_received_total[$RANGE])`,
 	"container_net_tcp_listen_info":             `container_net_tcp_listen_info`,
 	"container_net_tcp_retransmits":             `rate(container_net_tcp_retransmits_total[$RANGE])`,
 	"container_log_messages":                    `container_log_messages_total % 10000000`,

--- a/model/connection.go
+++ b/model/connection.go
@@ -46,6 +46,8 @@ type Connection struct {
 	Active                *timeseries.TimeSeries
 	FailedConnections     *timeseries.TimeSeries
 	ConnectionTime        *timeseries.TimeSeries
+	BytesSent             *timeseries.TimeSeries
+	BytesReceived         *timeseries.TimeSeries
 
 	Retransmissions *timeseries.TimeSeries
 
@@ -99,15 +101,18 @@ func (c *Connection) HasFailedConnectionAttempts() bool {
 	return c.FailedConnections.Last() > 0
 }
 
-func (c *Connection) Status() Status {
+func (c *Connection) Status() (Status, string) {
 	if !c.IsActual() {
-		return UNKNOWN
+		return UNKNOWN, ""
 	}
 	status := OK
-	if c.HasConnectivityIssues() || c.HasFailedConnectionAttempts() {
-		status = CRITICAL
+	switch {
+	case c.HasConnectivityIssues():
+		return CRITICAL, "connectivity issues"
+	case c.HasFailedConnectionAttempts():
+		return CRITICAL, "failed connections"
 	}
-	return status
+	return status, ""
 }
 
 func IsRequestStatusFailed(status string) bool {

--- a/utils/format.go
+++ b/utils/format.go
@@ -88,3 +88,32 @@ func LastPart(s string, sep string) string {
 	}
 	return parts[len(parts)-1]
 }
+
+func FormatLinkStats(requests, latency, bytesSent, bytesReceived float32, issue string) []string {
+	if issue != "" {
+		return []string{"⚠️ " + issue}
+	}
+	var res []string
+	line := ""
+	if !timeseries.IsNaN(requests) {
+		line += "📈 " + FormatFloat(requests) + " rps"
+	}
+	if !timeseries.IsNaN(latency) {
+		if len(line) > 0 {
+			line += " "
+		}
+		line += "⏱️ " + FormatLatency(latency)
+	}
+	if len(line) > 0 {
+		res = append(res, line)
+	}
+	if bytesSent > 0 || bytesReceived > 0 {
+		line = ""
+		v, u := FormatBytes(bytesSent)
+		line += "↑" + v + u + "/s"
+		v, u = FormatBytes(bytesReceived)
+		line += " ↓" + v + u + "/s"
+		res = append(res, line)
+	}
+	return res
+}


### PR DESCRIPTION
Coroot now shows Service-to-Service traffic. The metrics are measured at the TCP level and don't include IP and TCP headers, which can add 2-4%. These metrics only reflect the TCP payload size.

Traffic is show on Service Map:

<img width="1172" alt="Screenshot 2024-07-29 at 12 57 39" src="https://github.com/user-attachments/assets/9e26447f-1951-4e0d-aa3d-d069a7c811cc">

Application Dependency Map:

<img width="1184" alt="Screenshot 2024-07-29 at 13 05 00" src="https://github.com/user-attachments/assets/619b73ea-a03a-4021-b4eb-f381e689ff6a">


and in the Network inspection details:

<img width="560" alt="Screenshot 2024-07-29 at 13 06 43" src="https://github.com/user-attachments/assets/ff671a90-b322-46c4-9595-4bd38e6bd781">




