### PR TITLE
add `Internet egress` and `Cross-AZ` data transfer costs breakdown

### DIFF
--- a/api/views/overview/types.go
+++ b/api/views/overview/types.go
@@ -58,11 +58,13 @@ type resource struct {
 }
 
 type instance struct {
-	ownerId   model.ApplicationId
-	name      string
-	cpu       resource
-	memory    resource
-	nodePrice *model.NodePrice
+	ownerId             model.ApplicationId
+	name                string
+	cpu                 resource
+	memory              resource
+	crossAzTrafficCosts float32
+	internetEgressCosts float32
+	nodePrice           *model.NodePrice
 }
 
 func (i *instance) getResource(rt resourceType) resource {

--- a/cloud-pricing/model.go
+++ b/cloud-pricing/model.go
@@ -18,10 +18,19 @@ type DBInstancePricing struct {
 	MultiAz  *InstancePricing `json:"multi_az"`
 }
 
+type StartUsageAmountGB int64
+
+type DataTransferPricing struct {
+	IngressPerGB float64 `json:"ingress_per_gb"`
+	EgressPerGB  float64 `json:"egress_per_gb"`
+}
+
 type CloudPricing struct {
-	Compute      map[Region]map[InstanceType]*InstancePricing              `json:"compute"`
-	ManagedDB    map[Region]map[Engine]map[InstanceType]*DBInstancePricing `json:"managed_db"`
-	ManagedCache map[Region]map[Engine]map[InstanceType]*InstancePricing   `json:"managed_cache"`
+	Compute                 map[Region]map[InstanceType]*InstancePricing              `json:"compute"`
+	ManagedDB               map[Region]map[Engine]map[InstanceType]*DBInstancePricing `json:"managed_db"`
+	ManagedCache            map[Region]map[Engine]map[InstanceType]*InstancePricing   `json:"managed_cache"`
+	InternetEgress          map[Region]map[StartUsageAmountGB]float64                 `json:"internet_egress"`
+	IntraRegionDataTransfer map[Region]DataTransferPricing                            `json:"inter_region_data_transfer"`
 }
 
 type Model struct {

--- a/constructor/nodes.go
+++ b/constructor/nodes.go
@@ -115,6 +115,7 @@ func (c *Constructor) loadNodes(w *model.World, metrics map[string][]model.Metri
 	if c.pricing != nil {
 		for _, n := range w.Nodes {
 			n.Price = c.pricing.GetNodePrice(n)
+			n.DataTransferPrice = c.pricing.GetDataTransferPrice(n)
 		}
 	}
 }

--- a/front/src/components/ApplicationsCosts.vue
+++ b/front/src/components/ApplicationsCosts.vue
@@ -42,6 +42,8 @@
                 { value: 'usage_costs', text: 'Usage costs', align: 'end' },
                 { value: 'allocation_costs', text: 'Allocation costs', align: 'end' },
                 { value: 'over_provisioning_costs', text: 'Overprovisioning costs', align: 'end' },
+                { value: 'cross_az_traffic_costs', text: 'Cross-AZ traffic', align: 'end' },
+                { value: 'internet_egress_costs', text: 'Internet egress traffic', align: 'end' },
             ]"
             :footer-props="{ itemsPerPageOptions: [5, 10, 20, 50, 100, -1] }"
         >
@@ -61,6 +63,18 @@
                 </template>
                 <template v-else>—</template>
             </template>
+            <template #item.cross_az_traffic_costs="{ item }">
+                <template v-if="item.cross_az_traffic_costs > 0">
+                    ${{ item.cross_az_traffic_costs.toFixed(2) }}<span class="caption grey--text">/mo</span>
+                </template>
+                <template v-else>—</template>
+            </template>
+            <template #item.internet_egress_costs="{ item }">
+                <template v-if="item.internet_egress_costs > 0">
+                    ${{ item.internet_egress_costs.toFixed(2) }}<span class="caption grey--text">/mo</span>
+                </template>
+                <template v-else>—</template>
+            </template>
             <template #foot>
                 <tfoot>
                     <tr v-for="item in [categoriesTotal]">
@@ -77,6 +91,18 @@
                         <td class="font-weight-medium text-right">
                             <template v-if="item.over_provisioning_costs > 0">
                                 ${{ item.over_provisioning_costs.toFixed(2) }}<span class="caption grey--text">/mo</span>
+                            </template>
+                            <template v-else>—</template>
+                        </td>
+                        <td class="font-weight-medium text-right">
+                            <template v-if="item.cross_az_traffic_costs > 0">
+                                ${{ item.cross_az_traffic_costs.toFixed(2) }}<span class="caption grey--text">/mo</span>
+                            </template>
+                            <template v-else>—</template>
+                        </td>
+                        <td class="font-weight-medium text-right">
+                            <template v-if="item.internet_egress_costs > 0">
+                                ${{ item.internet_egress_costs.toFixed(2) }}<span class="caption grey--text">/mo</span>
                             </template>
                             <template v-else>—</template>
                         </td>
@@ -101,6 +127,8 @@
                 { value: 'usage_costs', text: 'Usage costs', align: 'end', filterable: false },
                 { value: 'allocation_costs', text: 'Allocation costs', align: 'end', filterable: false },
                 { value: 'over_provisioning_costs', text: 'Overprovisioning costs', align: 'end', filterable: false },
+                { value: 'cross_az_traffic_costs', text: 'Cross-AZ traffic', align: 'end', filterable: false },
+                { value: 'internet_egress_costs', text: 'Internet egress traffic', align: 'end', filterable: false },
             ]"
             :footer-props="{ itemsPerPageOptions: [10, 20, 50, 100, -1] }"
             :search="search"
@@ -119,6 +147,18 @@
             <template #item.over_provisioning_costs="{ item }">
                 <template v-if="item.over_provisioning_costs > 0">
                     ${{ item.over_provisioning_costs.toFixed(2) }}<span class="caption grey--text">/mo</span>
+                </template>
+                <template v-else>—</template>
+            </template>
+            <template #item.cross_az_traffic_costs="{ item }">
+                <template v-if="item.cross_az_traffic_costs > 0">
+                    ${{ item.cross_az_traffic_costs.toFixed(2) }}<span class="caption grey--text">/mo</span>
+                </template>
+                <template v-else>—</template>
+            </template>
+            <template #item.internet_egress_costs="{ item }">
+                <template v-if="item.internet_egress_costs > 0">
+                    ${{ item.internet_egress_costs.toFixed(2) }}<span class="caption grey--text">/mo</span>
                 </template>
                 <template v-else>—</template>
             </template>
@@ -224,23 +264,38 @@ export default {
             this.applications.forEach((a) => {
                 let c = cs.get(a.category);
                 if (!c) {
-                    c = { name: a.category, usage_costs: 0, allocation_costs: 0, over_provisioning_costs: 0 };
+                    c = {
+                        name: a.category,
+                        usage_costs: 0,
+                        allocation_costs: 0,
+                        over_provisioning_costs: 0,
+                        cross_az_traffic_costs: 0,
+                        internet_egress_costs: 0,
+                    };
                 }
                 c.usage_costs += a.usage_costs;
                 c.allocation_costs += a.allocation_costs;
                 if (a.over_provisioning_costs > 0) {
                     c.over_provisioning_costs += a.over_provisioning_costs;
                 }
+                if (a.cross_az_traffic_costs > 0) {
+                    c.cross_az_traffic_costs += a.cross_az_traffic_costs;
+                }
+                if (a.internet_egress_costs > 0) {
+                    c.internet_egress_costs += a.internet_egress_costs;
+                }
                 cs.set(c.name, c);
             });
             return Array.from(cs.values());
         },
         categoriesTotal() {
-            const res = { usage_costs: 0, allocation_costs: 0, over_provisioning_costs: 0 };
+            const res = { usage_costs: 0, allocation_costs: 0, over_provisioning_costs: 0, cross_az_traffic_costs: 0, internet_egress_costs: 0 };
             this.categories.forEach((c) => {
                 res.usage_costs += c.usage_costs;
                 res.allocation_costs += c.allocation_costs;
                 res.over_provisioning_costs += c.over_provisioning_costs;
+                res.cross_az_traffic_costs += c.cross_az_traffic_costs;
+                res.internet_egress_costs += c.internet_egress_costs;
             });
             return res;
         },

--- a/front/src/components/NodesCosts.vue
+++ b/front/src/components/NodesCosts.vue
@@ -22,7 +22,9 @@
                 { value: 'cpu_usage', text: 'CPU', align: 'center', width: '25%' },
                 { value: 'memory_usage', text: 'Memory', align: 'center', width: '25%' },
                 { value: 'price', text: 'Price', align: 'end' },
-                { value: 'idle_costs', text: 'Idle costs', align: 'end', class: 'text-no-wrap' },
+                { value: 'idle_costs', text: 'Idle cost', align: 'end', class: 'text-no-wrap' },
+                { value: 'cross_az_traffic_costs', text: 'Cross-AZ traffic', align: 'end', class: 'text-no-wrap' },
+                { value: 'internet_egress_costs', text: 'Internet egress traffic', align: 'end', class: 'text-no-wrap' },
             ]"
             :footer-props="{ itemsPerPageOptions: [10, 20, 50, 100, -1] }"
         >
@@ -47,6 +49,12 @@
                 <div class="caption grey--text">{{ item.instance_life_cycle }}</div>
             </template>
             <template #item.idle_costs="{ item }"> ${{ item.idle_costs.toFixed(2) }}<span class="caption grey--text">/mo</span> </template>
+            <template #item.cross_az_traffic_costs="{ item }">
+                ${{ item.cross_az_traffic_costs.toFixed(2) }}<span class="caption grey--text">/mo</span>
+            </template>
+            <template #item.internet_egress_costs="{ item }">
+                ${{ item.internet_egress_costs.toFixed(2) }}<span class="caption grey--text">/mo</span>
+            </template>
 
             <template #foot>
                 <tfoot>
@@ -57,6 +65,12 @@
                         <td></td>
                         <td class="text-right font-weight-medium">${{ item.price.toFixed(2) }}<span class="caption grey--text">/mo</span></td>
                         <td class="text-right font-weight-medium">${{ item.idle_costs.toFixed(2) }}<span class="caption grey--text">/mo</span></td>
+                        <td class="text-right font-weight-medium">
+                            ${{ item.cross_az_traffic_costs.toFixed(2) }}<span class="caption grey--text">/mo</span>
+                        </td>
+                        <td class="text-right font-weight-medium">
+                            ${{ item.internet_egress_costs.toFixed(2) }}<span class="caption grey--text">/mo</span>
+                        </td>
                     </tr>
                 </tfoot>
             </template>
@@ -76,10 +90,12 @@ export default {
 
     computed: {
         total() {
-            const res = { price: 0, idle_costs: 0 };
+            const res = { price: 0, idle_costs: 0, cross_az_traffic_costs: 0, internet_egress_costs: 0 };
             this.nodes.forEach((n) => {
                 res.price += n.price;
                 res.idle_costs += n.idle_costs;
+                res.cross_az_traffic_costs += n.cross_az_traffic_costs;
+                res.internet_egress_costs += n.internet_egress_costs;
             });
             return res;
         },

--- a/model/node.go
+++ b/model/node.go
@@ -82,14 +82,37 @@ type Node struct {
 	InstanceType      LabelLastValue
 	InstanceLifeCycle LabelLastValue
 
-	Fargate bool
-	Price   *NodePrice
+	Fargate           bool
+	Price             *NodePrice
+	DataTransferPrice *DataTransferPrice
 }
 
 type NodePrice struct {
 	Total         float32
 	PerCPUCore    float32
 	PerMemoryByte float32
+}
+
+type InternetStartUsageAmountGB int64
+
+type DataTransferPrice struct {
+	InterZoneIngressPerGB float32
+	InterZoneEgressPerGB  float32
+	InternetPerGB         map[InternetStartUsageAmountGB]float32
+}
+
+func (dtp *DataTransferPrice) GetInternetEgressPrice() float32 {
+	// so far it returns the price with minimum InternetStartUsageAmountGB
+	var minThreshold InternetStartUsageAmountGB = -1
+	var price float32
+
+	for threshold, p := range dtp.InternetPerGB {
+		if minThreshold == -1 || threshold < minThreshold {
+			minThreshold = threshold
+			price = p
+		}
+	}
+	return price
 }
 
 func NewNode(id NodeId) *Node {

--- a/utils/ip.go
+++ b/utils/ip.go
@@ -20,3 +20,7 @@ func IsIpPrivate(ip netaddr.IP) bool {
 func IsIpDocker(ip netaddr.IP) bool {
 	return dockerNetwork.Contains(ip)
 }
+
+func IsIpExternal(ip netaddr.IP) bool {
+	return !ip.IsLoopback() && !ip.IsPrivate()
+}


### PR DESCRIPTION
Coroot now calculates data transfer costs for cross-AZ traffic and Internet Egress.

Nodes:

<img width="1185" alt="Screenshot 2024-08-01 at 18 27 33" src="https://github.com/user-attachments/assets/49828d1c-4b68-4507-a137-508980b5bdd7">

Applications:

<img width="1189" alt="Screenshot 2024-08-01 at 18 28 19" src="https://github.com/user-attachments/assets/eb96c3f9-ddad-4a6e-a15b-8381d62f902f">

Limitations:
 * Only the TCP payload is considered, without TCP/IP headers
 * Only outbound TCP connections are taken into account 
 * The free tier is not supported yet
* The first tier of Internet Egress pricing is used
* Cross-region data transfer pricing is not taken into account