### PR TITLE
add additional patterns to the app category

### DIFF
--- a/model/application_category.go
+++ b/model/application_category.go
@@ -65,6 +65,9 @@ var BuiltinCategoryPatterns = map[ApplicationCategory][]string{
 		"_/*apt*",
 		"_/*fwupd*",
 		"_/snap*",
+		"keptn-system/*",
+		"kyverno/*",
+		"litmus/*",
 	},
 	ApplicationCategoryMonitoring: {
 		"monitoring/*",
@@ -76,6 +79,8 @@ var BuiltinCategoryPatterns = map[ApplicationCategory][]string{
 		"coroot/*",
 		"*/*coroot*",
 		"metrics-server/*",
+		"loki/*",
+		"observability/*",
 	},
 }
 


### PR DESCRIPTION
Added namespaces to the `ApplicationCategoryControlPlane`:
- `keptn-system` - Cloud-native application life-cycle orchestration. Keptn automates your SLO-driven multi-stage delivery and operations & remediation of your applications.
- `kyverno` - Cloud Native Policy Management
- `litmus` - Litmus helps SREs and developers practice chaos engineering in a Cloud-native way. Chaos experiments are published at the ChaosHub (https://hub.litmuschaos.io/). Community notes is at https://hackmd.io/a4Zu_sH4TZGeih-xCimi3Q

Added namespaces to the `ApplicationCategoryMonitoring`:
- `loki` - Like Prometheus, but for logs
- `observability` - used by various companies and applications as a naming convention for monitoring components