### PR TITLE
[Bug]: Fix install failed by Permission denied.

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -191,8 +191,8 @@ create_env_file() {
             if [ -z $interval ]; then
                 interval=15s
             fi
-            echo "COROOT_URL='http://${host}:${port}'" >> ${FILE_ENV}
-            echo "METRICS_SCRAPE_INTERVAL='${interval}'" >> ${FILE_ENV}
+            $SUDO sh -c "echo \"COROOT_URL='http://${host}:${port}'\" >> ${FILE_ENV}"
+            $SUDO sh -c "echo \"METRICS_SCRAPE_INTERVAL='${interval}'\" >> ${FILE_ENV}"
             ;;
     esac
 }


### PR DESCRIPTION
Hello.

I ran the `deploy/install.sh` according to the documentation, but I got a permission error.

```
seinoyu@ubuntu2404:~/coroot$ uname -a
Linux ubuntu2404 6.8.0-49-generic #49-Ubuntu SMP PREEMPT_DYNAMIC Mon Nov  4 02:06:24 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
seinoyu@ubuntu2404:~/coroot$ curl -sfL https://raw.githubusercontent.com/coroot/coroot/main/deploy/install.sh | \
  BOOTSTRAP_PROMETHEUS_URL="http://127.0.0.1:9090" \
  BOOTSTRAP_REFRESH_INTERVAL=15s \
  BOOTSTRAP_CLICKHOUSE_ADDRESS=127.0.0.1:9000 \
  sh -
[INFO]  Creating uninstall script /usr/bin/coroot-uninstall.sh
*** INSTALLING coroot ***
[INFO]  Finding the latest release
[INFO]  The latest release is v1.6.8
[INFO]  Downloading binary
[INFO]  Installing to /usr/bin/coroot
[INFO]  env: Creating environment file /etc/systemd/system/coroot.service.env
[INFO]  systemd: Creating service file /etc/systemd/system/coroot.service
[INFO]  systemd: Enabling coroot
Created symlink /etc/systemd/system/multi-user.target.wants/coroot.service → /etc/systemd/system/coroot.service.
[INFO]  systemd: Starting coroot
*** INSTALLING coroot-cluster-agent ***
[INFO]  Finding the latest release
[INFO]  The latest release is v1.1.2
[INFO]  Downloading binary
[INFO]  Installing to /usr/bin/coroot-cluster-agent
[INFO]  env: Creating environment file /etc/systemd/system/coroot-cluster-agent.service.env
sh: 194: cannot create /etc/systemd/system/coroot-cluster-agent.service.env: Permission denied
```