### PR TITLE
add: func collector to VictoriaMetrics

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -62,9 +62,10 @@ type Collector struct {
 	logBatchesLock     sync.Mutex
 	profileBatches     map[db.ProjectId]*ProfilesBatch
 	profileBatchesLock sync.Mutex
+	FixedURL           string
 }
 
-func New(database *db.DB, cache *cache.Cache, globalClickHouse *db.IntegrationClickhouse, globalPrometheus *db.IntegrationPrometheus) *Collector {
+func New(database *db.DB, cache *cache.Cache, globalClickHouse *db.IntegrationClickhouse, globalPrometheus *db.IntegrationPrometheus, fixedURL string) *Collector {
 	c := &Collector{
 		db:                database,
 		cache:             cache,
@@ -75,6 +76,7 @@ func New(database *db.DB, cache *cache.Cache, globalClickHouse *db.IntegrationCl
 		traceBatches:      map[db.ProjectId]*TracesBatch{},
 		profileBatches:    map[db.ProjectId]*ProfilesBatch{},
 		logBatches:        map[db.ProjectId]*LogsBatch{},
+		FixedURL:          fixedURL,
 	}
 
 	c.updateProjects()

--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -82,7 +82,13 @@ func (c *Collector) Metrics(w http.ResponseWriter, r *http.Request) {
 		u.User = url.UserPassword(cfg.BasicAuth.User, cfg.BasicAuth.Password)
 	}
 
-	u = u.JoinPath("/api/v1/write")
+	var requestURL string
+	if c.FixedURL != "" {
+		requestURL = c.FixedURL
+	} else {
+		u = u.JoinPath("/api/v1/write")
+		requestURL = u.String()
+	}
 
 	body, err := addLabelsIfNeeded(r, cfg.ExtraLabels)
 	if err != nil {
@@ -91,7 +97,7 @@ func (c *Collector) Metrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	req, err := http.NewRequestWithContext(r.Context(), r.Method, u.String(), body)
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, requestURL, body)
 	if err != nil {
 		klog.Errorln(err)
 		http.Error(w, "", http.StatusInternalServerError)

--- a/config/config.go
+++ b/config/config.go
@@ -40,6 +40,8 @@ type Config struct {
 
 	BootstrapClickhouse *Clickhouse `yaml:"-"`
 	BootstrapPrometheus *Prometheus `yaml:"-"`
+
+	CollectorFixedURL string `yaml:"collector_url_prometheus"`
 }
 
 type Cache struct {

--- a/config/flags.go
+++ b/config/flags.go
@@ -42,6 +42,7 @@ var (
 	bootstrapClickhouseUser          = kingpin.Flag("bootstrap-clickhouse-user", "").Envar("BOOTSTRAP_CLICKHOUSE_USER").String()
 	bootstrapClickhousePassword      = kingpin.Flag("bootstrap-clickhouse-password", "").Envar("BOOTSTRAP_CLICKHOUSE_PASSWORD").String()
 	bootstrapClickhouseDatabase      = kingpin.Flag("bootstrap-clickhouse-database", "").Envar("BOOTSTRAP_CLICKHOUSE_DATABASE").String()
+	collectorFixedURL                = kingpin.Flag("collectorMetrics", "Victoria Metrics URL for metrics collection").Envar("COLLECTOR_METRICS").Default("").String()
 )
 
 func (cfg *Config) applyFlags() {
@@ -154,5 +155,8 @@ func (cfg *Config) applyFlags() {
 			Password: *bootstrapClickhousePassword,
 			Database: *bootstrapClickhouseDatabase,
 		}
+	}
+	if *collectorFixedURL != "" {
+		cfg.CollectorFixedURL = *collectorFixedURL
 	}
 }

--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ func main() {
 
 	globalClickhouse := cfg.GetGlobalClickhouse()
 	globalPrometheus := cfg.GetGlobalPrometheus()
+	globalCollectorFixedURL := cfg.CollectorFixedURL
 
 	cacheConfig := cache.Config{
 		Path: path.Join(cfg.DataDir, "cache"),
@@ -94,7 +95,7 @@ func main() {
 		klog.Exitln(err)
 	}
 
-	coll := collector.New(database, promCache, globalClickhouse, globalPrometheus)
+	coll := collector.New(database, promCache, globalClickhouse, globalPrometheus, globalCollectorFixedURL)
 	go func() {
 		ch := make(chan os.Signal, 1)
 		signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)


### PR DESCRIPTION
Hello! 

You can add new functionality by victoriametrics [issues](https://github.com/coroot/coroot/issues/400) .  

For a collector that is not in Kubernetes , add args: 

```
--collectorMetrics=http://victoria-metrics-cluster-vminsert.monitoring.svc.cluster.local:8480/insert/0/prometheus
```

```
victoria-metrics-cluster-vminsert - name service vminsert 
monitoring - namespace 
/insert/0/prometheus - api vminsert
```

if you don't specify a launch argumentc (collectorMetrics) coroot

run default (collector/metrics.go)  u = u.JoinPath("/api/v1/write")
```go
var requestURL string
	if c.FixedURL != "" {
		requestURL = c.FixedURL
	} else {
		u = u.JoinPath("/api/v1/write")
		requestURL = u.String()
	}
```
