### PR TITLE
Update requirements.md to update the minimum required Linux kernel version.

### DIFF
--- a/docs/docs/installation/requirements.md
+++ b/docs/docs/installation/requirements.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Requirements
 
- * Coroot relies heavily on eBPF, therefore, the minimum supported Linux kernel version is 4.16.
+ * Coroot relies heavily on eBPF, therefore, the minimum supported Linux kernel version is 5.1.
  * eBPF-based continuous profiling utilizes CO-RE. CO-RE is supported by most modern Linux distributions, including:
    * Ubuntu 20.10 and above 
    * Debian 11 and above 


### PR DESCRIPTION
Fixes https://github.com/coroot/coroot-node-agent/issues/106

Update the documentation to specify that the minimum supported Kernel version is 5.1.