### PR TITLE
docker-compose: disable user setup in clickhouse entrypoint script

### DIFF
--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -76,6 +76,8 @@ services:
   clickhouse:
     restart: always
     image: clickhouse/clickhouse-server:24.3
+    environment:
+      CLICKHOUSE_SKIP_USER_SETUP: "1"
     volumes:
       - clickhouse_data:/var/lib/clickhouse
       - clickhouse_logs:/var/log/clickhouse-server


### PR DESCRIPTION
At some point `clickhouse` started to limit the "default" user to access from localhost only (127.0.0.1 / ::1) but coroot expects to be able to access `clickhouse` from the `coroot` container via docker networking.

fixes #534