### PR TITLE
docs: add annotations section for Service in k8s-operator installation guide

### DIFF
--- a/docs/docs/installation/k8s-operator.md
+++ b/docs/docs/installation/k8s-operator.md
@@ -58,6 +58,7 @@ spec:
 #    type: # Service type (e.g., ClusterIP, NodePort, LoadBalancer).
 #    port: # Service port number.
 #    nodePort: # NodePort number (if type is NodePort).
+#    annotations: # Annotations for Service.
 #  ingress: # Ingress configuration for Coroot.
 #    className: Ingress class name (e.g., nginx, traefik; if not set the default IngressClass will be used).
 #    host: # Domain name for Coroot (e.g., coroot.company.com).


### PR DESCRIPTION
This update to the Coroot Operator introduces the ability to specify custom annotations for the Kubernetes Service resource that the operator manages. This enhancement provides users with greater flexibility to integrate the coroot service with other tools or to leverage specific Kubernetes features that rely on service annotations.