### PR TITLE
Disable logs exporter in Java example for OpenTelemetry 

### DIFF
--- a/docs/docs/tracing/opentelemetry-java.md
+++ b/docs/docs/tracing/opentelemetry-java.md
@@ -49,6 +49,7 @@ export \
   OTEL_SERVICE_NAME="spring-demo" \
   OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://coroot.coroot:8080/v1/traces" \
   OTEL_EXPORTER_OTLP_TRACES_PROTOCOL="http/protobuf" \
+  OTEL_LOGS_EXPORTER="none" \
   OTEL_METRICS_EXPORTER="none" \
 && java -javaagent:./opentelemetry-javaagent.jar -jar build/libs/demo-0.0.1-SNAPSHOT.jar
 ```


### PR DESCRIPTION
I used the example from your documentation and observed that my Java process was filling the logs with exceptions about not being able to deliver logs via OpenTelemetry. This disables the logs feature of the agent.

Alternative:
I can rework this to instead also send logs via OpenTelemetry, please comment if you like it that way.