### PR TITLE
config: add support for notification integrations, application categories, and custom applications

### DIFF
--- a/api/forms/forms.go
+++ b/api/forms/forms.go
@@ -473,7 +473,7 @@ type IntegrationFormSlack struct {
 }
 
 func (f *IntegrationFormSlack) Valid() bool {
-	if f.Token == "" || f.DefaultChannel == "" {
+	if err := f.Validate(); err != nil {
 		return false
 	}
 	return true
@@ -510,7 +510,7 @@ type IntegrationFormTeams struct {
 }
 
 func (f *IntegrationFormTeams) Valid() bool {
-	if f.WebhookUrl == "" {
+	if err := f.Validate(); err != nil {
 		return false
 	}
 	return true
@@ -547,7 +547,7 @@ type IntegrationFormPagerduty struct {
 }
 
 func (f *IntegrationFormPagerduty) Valid() bool {
-	if f.IntegrationKey == "" {
+	if err := f.Validate(); err != nil {
 		return false
 	}
 	return true
@@ -583,7 +583,7 @@ type IntegrationFormOpsgenie struct {
 }
 
 func (f *IntegrationFormOpsgenie) Valid() bool {
-	if f.ApiKey == "" {
+	if err := f.Validate(); err != nil {
 		return false
 	}
 	return true
@@ -619,13 +619,7 @@ type IntegrationFormWebhook struct {
 }
 
 func (f *IntegrationFormWebhook) Valid() bool {
-	if f.Url == "" {
-		return false
-	}
-	if f.Incidents && f.IncidentTemplate == "" {
-		return false
-	}
-	if f.Deployments && f.DeploymentTemplate == "" {
+	if err := f.Validate(); err != nil {
 		return false
 	}
 	return true

--- a/api/views/applications/custom_applications.go
+++ b/api/views/applications/custom_applications.go
@@ -21,7 +21,7 @@ func RenderCustomApplications(p *db.Project) *CustomApplicationsView {
 	for name, app := range p.Settings.CustomApplications {
 		v.CustomApplications = append(v.CustomApplications, CustomApplication{
 			Name:             name,
-			InstancePatterns: strings.Join(app.InstancePattens, " "),
+			InstancePatterns: strings.Join(app.InstancePatterns, " "),
 		})
 	}
 	sort.Slice(v.CustomApplications, func(i, j int) bool {

--- a/config/flags.go
+++ b/config/flags.go
@@ -24,7 +24,6 @@ var (
 	authAnonymousRole          = kingpin.Flag("auth-anonymous-role", "Disable authentication and assign one of the following roles to the anonymous user: Admin, Editor, or Viewer.").Envar("AUTH_ANONYMOUS_ROLE").String()
 	authBootstrapAdminPassword = kingpin.Flag("auth-bootstrap-admin-password", "Password for the default Admin user").Envar("AUTH_BOOTSTRAP_ADMIN_PASSWORD").String()
 	developerMode              = kingpin.Flag("developer-mode", "If enabled, Coroot will not use embedded static assets").Envar("DEVELOPER_MODE").Bool()
-	licenseKey                 = kingpin.Flag("license-key", "License key for Coroot Enterprise Edition.").Envar("LICENSE_KEY").String()
 
 	globalClickhouseAddress         = kingpin.Flag("global-clickhouse-address", "").Envar("GLOBAL_CLICKHOUSE_ADDRESS").String()
 	globalClickhouseUser            = kingpin.Flag("global-clickhouse-user", "").Envar("GLOBAL_CLICKHOUSE_USER").String()
@@ -52,7 +51,7 @@ var (
 	bootstrapClickhouseDatabase = kingpin.Flag("bootstrap-clickhouse-database", "").Envar("BOOTSTRAP_CLICKHOUSE_DATABASE").String()
 )
 
-func (cfg *Config) applyFlags() {
+func (cfg *Config) ApplyFlags() {
 	if *listen != "" {
 		cfg.ListenAddress = *listen
 	}
@@ -100,9 +99,6 @@ func (cfg *Config) applyFlags() {
 	}
 	if *developerMode {
 		cfg.DeveloperMode = *developerMode
-	}
-	if *licenseKey != "" {
-		cfg.LicenseKey = *licenseKey
 	}
 
 	keep := cfg.GlobalClickhouse != nil || *globalClickhouseAddress != ""

--- a/config/project.go
+++ b/config/project.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/coroot/coroot/db"
+	"github.com/coroot/coroot/model"
+)
+
+type Project struct {
+	Name string `yaml:"name"`
+
+	ApiKeys      []db.ApiKey `yaml:"apiKeys"`
+	ApiKeysSnake []db.ApiKey `yaml:"api_keys"` // TODO: remove
+
+	NotificationIntegrations *db.NotificationIntegrations `yaml:"notificationIntegrations"`
+	ApplicationCategories    []ApplicationCategory        `yaml:"applicationCategories"`
+	CustomApplications       []CustomApplication          `yaml:"customApplications"`
+}
+
+func (p *Project) Validate() error {
+	if p.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+
+	if len(p.ApiKeys) == 0 {
+		p.ApiKeys = p.ApiKeysSnake
+	}
+	if len(p.ApiKeys) == 0 {
+		return fmt.Errorf("no api keys defined")
+	}
+	for i, k := range p.ApiKeys {
+		if err := k.Validate(); err != nil {
+			return fmt.Errorf("invalid api key #%d: %w", i, err)
+		}
+	}
+
+	if p.NotificationIntegrations != nil {
+		if err := p.NotificationIntegrations.Validate(); err != nil {
+			return fmt.Errorf("invalid notification integrations: %w", err)
+		}
+	}
+
+	for i, c := range p.ApplicationCategories {
+		if err := c.Validate(); err != nil {
+			return fmt.Errorf("invalid application category #%d: %w", i, err)
+		}
+	}
+
+	for i, c := range p.CustomApplications {
+		if err := c.Validate(); err != nil {
+			return fmt.Errorf("invalid custom application #%d: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+type ApplicationCategory struct {
+	Name                           model.ApplicationCategory `yaml:"name"`
+	db.ApplicationCategorySettings `yaml:",inline"`
+}
+
+func (c *ApplicationCategory) Validate() error {
+	if c.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	return nil
+}
+
+type CustomApplication struct {
+	Name                    string `yaml:"name"`
+	model.CustomApplication `yaml:",inline"`
+}
+
+func (c *CustomApplication) Validate() error {
+	if c.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	return nil
+}

--- a/constructor/constructor.go
+++ b/constructor/constructor.go
@@ -241,7 +241,6 @@ func (c *Constructor) queryCache(ctx context.Context, from, to timeseries.Time, 
 func (c *Constructor) calcApplicationCategories(w *model.World) {
 	for _, app := range w.Applications {
 		if annotation := app.GetAnnotation(model.ApplicationAnnotationCategory); annotation != "" {
-			klog.Infoln(app.Id, annotation)
 			app.Category = model.ApplicationCategory(annotation)
 			continue
 		}

--- a/db/application_categories.go
+++ b/db/application_categories.go
@@ -19,32 +19,32 @@ type ApplicationCategory struct {
 }
 
 type ApplicationCategorySettings struct {
-	CustomPatterns       []string                                `json:"custom_patterns,omitempty"`
+	CustomPatterns       []string                                `json:"custom_patterns,omitempty" yaml:"customPatterns,omitempty"`
 	NotifyOfDeployments  bool                                    `json:"notify_of_deployments,omitempty"` // deprecated: use NotificationSettings
-	NotificationSettings ApplicationCategoryNotificationSettings `json:"notification_settings"`
+	NotificationSettings ApplicationCategoryNotificationSettings `json:"notification_settings,omitempty" yaml:"notificationSettings,omitempty"`
 }
 
 type ApplicationCategoryNotificationSettings struct {
-	Incidents   ApplicationCategoryIncidentNotificationSettings   `json:"incidents,omitempty"`
-	Deployments ApplicationCategoryDeploymentNotificationSettings `json:"deployments,omitempty"`
+	Incidents   ApplicationCategoryIncidentNotificationSettings   `json:"incidents,omitempty" yaml:"incidents,omitempty"`
+	Deployments ApplicationCategoryDeploymentNotificationSettings `json:"deployments,omitempty" yaml:"deployments,omitempty"`
 }
 
 type ApplicationCategoryIncidentNotificationSettings struct {
-	Enabled bool `json:"enabled"`
-	ApplicationCategoryNotificationDestinations
+	Enabled                                     bool `json:"enabled" yaml:"enabled"`
+	ApplicationCategoryNotificationDestinations `yaml:",inline"`
 }
 
 type ApplicationCategoryDeploymentNotificationSettings struct {
-	Enabled bool `json:"enabled"`
-	ApplicationCategoryNotificationDestinations
+	Enabled                                     bool `json:"enabled" yaml:"enabled"`
+	ApplicationCategoryNotificationDestinations `yaml:",inline"`
 }
 
 type ApplicationCategoryNotificationDestinations struct {
-	Slack     *ApplicationCategoryNotificationSettingsSlack     `json:"slack,omitempty"`
-	Teams     *ApplicationCategoryNotificationSettingsTeams     `json:"teams,omitempty"`
-	Pagerduty *ApplicationCategoryNotificationSettingsPagerduty `json:"pagerduty,omitempty"`
-	Opsgenie  *ApplicationCategoryNotificationSettingsOpsgenie  `json:"opsgenie,omitempty"`
-	Webhook   *ApplicationCategoryNotificationSettingsWebhook   `json:"webhook,omitempty"`
+	Slack     *ApplicationCategoryNotificationSettingsSlack     `json:"slack,omitempty" yaml:"slack,omitempty"`
+	Teams     *ApplicationCategoryNotificationSettingsTeams     `json:"teams,omitempty" yaml:"teams,omitempty"`
+	Pagerduty *ApplicationCategoryNotificationSettingsPagerduty `json:"pagerduty,omitempty" yaml:"pagerduty,omitempty"`
+	Opsgenie  *ApplicationCategoryNotificationSettingsOpsgenie  `json:"opsgenie,omitempty" yaml:"opsgenie,omitempty"`
+	Webhook   *ApplicationCategoryNotificationSettingsWebhook   `json:"webhook,omitempty" yaml:"webhook,omitempty"`
 }
 
 func (s ApplicationCategoryNotificationDestinations) hasEnabled() bool {
@@ -56,24 +56,24 @@ func (s ApplicationCategoryNotificationDestinations) hasEnabled() bool {
 }
 
 type ApplicationCategoryNotificationSettingsSlack struct {
-	Enabled bool   `json:"enabled"`
-	Channel string `json:"channel"`
+	Enabled bool   `json:"enabled" yaml:"enabled"`
+	Channel string `json:"channel" yaml:"channel"`
 }
 
 type ApplicationCategoryNotificationSettingsTeams struct {
-	Enabled bool `json:"enabled"`
+	Enabled bool `json:"enabled" yaml:"enabled"`
 }
 
 type ApplicationCategoryNotificationSettingsPagerduty struct {
-	Enabled bool `json:"enabled"`
+	Enabled bool `json:"enabled" yaml:"enabled"`
 }
 
 type ApplicationCategoryNotificationSettingsOpsgenie struct {
-	Enabled bool `json:"enabled"`
+	Enabled bool `json:"enabled" yaml:"enabled"`
 }
 
 type ApplicationCategoryNotificationSettingsWebhook struct {
-	Enabled bool `json:"enabled"`
+	Enabled bool `json:"enabled" yaml:"enabled"`
 }
 
 func (p *Project) CalcApplicationCategory(appId model.ApplicationId) model.ApplicationCategory {

--- a/docs/docs/alerting/webhook.md
+++ b/docs/docs/alerting/webhook.md
@@ -93,7 +93,7 @@ Deployment of {{ .Application.Name }}@{{ .Application.Namespace }}
 ```
    </TabItem>
    <TabItem value="json" label="JSON">
-If the system you aim to integrate accepts JSON-formatted messages, you can employ the built-in json template function:
+If the system you aim to integrate accepts JSON-formatted messages, you can employ the built-in `json` template function:
 
 ```gotemplate
 {{ json . }}

--- a/docs/docs/configuration/configuration.md
+++ b/docs/docs/configuration/configuration.md
@@ -114,10 +114,101 @@ license_key: # License key for Coroot Enterprise Edition.
 # The project defined here will be created if it does not exist 
 #  and will be configured with the provided API keys.
 # If a project with the same name already exists (e.g., configured via the UI), 
-#  its API keys will be replaced.
+#  its API keys and other settings will be replaced.
 projects: # Create or update projects (configuration file only).
   - name:     # Project name (e.g., production, staging; must be unique; required).
-    api_keys: # Project API keys, used by agents to send telemetry data (required).
+    # Project API keys, used by agents to send telemetry data (required).
+    apiKeys:
       - key:         # Random string or UUID (must be unique; required).
         description: # The API key description (optional).
+    # Project notification integrations.
+    notificationIntegrations:
+      baseURL: # The URL of Coroot instance (required). Used for generating links in notifications.
+      slack:
+        token:              # Slack Bot User OAuth Token (required).
+        defaultChannel:     # Default channel (required).
+        incidents: false    # Notify of incidents (SLO violations).
+        deployments: false  # Notify of deployments.
+      teams:
+        webhookURL:         # Microsoft Teams Webhook URL (required).
+        incidents: false    # Notify of incidents (SLO violations).
+        deployments: false  # Notify of deployments.
+      pagerduty:
+        integrationKey:     # PagerDuty Integration Key (required).
+        incidents: false    # Notify of incidents (SLO violations).
+      opsgenie:
+        apiKey:             # Opsgenie API Key (required).
+        euInstance: false   # EU instance of Opsgenie.
+        incidents: false    # Notify of incidents (SLO violations).
+      webhook:
+        url:                    # Webhook URL (required).
+        tlsSkipVerify: false    # Whether to skip verification of the Webhook server's TLS certificate.
+        basicAuth:              # Basic auth credentials.
+          username:
+          password:
+        customHeaders:          # Custom headers to include in requests.
+          - key:
+            value:
+        incidents: false        # Notify of incidents (SLO violations).
+        deployments: false      # Notify of deployments.
+        incidentTemplate: ""    # Incident template (required if `incidents: true`).
+        deploymentTemplate: ""  # Deployment template (required if `deployments: true`).
+    # Project application category settings.
+    applicationCategories:
+      - name:               # Application category name (required).
+        customPatterns:     # List of glob patterns in the <namespace>/<application_name> format.
+          - staging/*
+          - test-*/*
+        notificationSettings: # Category notification settings.
+          incidents:          # Notify of incidents (SLO violations).
+            enabled: true
+            slack:
+              enabled: true
+              channel: ops
+            teams:
+              enabled: false
+            pagerduty:
+              enabled: false
+            opsgenie:
+              enabled: false
+            webhook:
+              enabled: false
+          deployments:        # Notify of deployments.
+            enabled: true
+            slack:
+              enabled: true
+              channel: general
+            teams:
+              enabled: false
+            webhook:
+              enabled: false
+    # Project custom applications settings.
+    customApplications:
+      - name: custom-app
+        instancePatterns:
+          - app@node1
+          - app@node2
+
+# Single Sign-on configuration (Coroot Enterprise edition only).
+sso:
+  enabled: false
+  defaultRole: Viewer # Default role for authenticated users (Admin, Editor, Viewer, or a custom role).
+  saml:
+    # SAML Identity Provider Metadata XML (required).
+    metadata: |
+      <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="http://www.okta.com/exkk72*********n5d7">
+        ...
+      </md:EntityDescriptor>
+
+# AI configuration (Coroot Enterprise edition only).
+ai:
+  provider: # AI model provider (one of: anthropic, openai, or openai_compatible).
+  anthropic:
+    apiKey: # Anthropic API key. 
+  openai:
+    apiKey: # OpenAI API key.
+  openaiCompatible:
+    apiKey:   # API key.
+    baseUrl:  # Base URL (e.g., https://generativelanguage.googleapis.com/v1beta/openai).
+    model:    # Model name (e.g., gemini-2.5-pro-preview-06-05).
 ```

--- a/front/src/views/IntegrationAI.vue
+++ b/front/src/views/IntegrationAI.vue
@@ -8,7 +8,10 @@
             Available exclusively in Coroot Enterprise (from $1 per CPU core/month).<br />
             <a href="https://coroot.com/account" target="_blank" class="font-weight-bold">Start</a> your free trial today.
         </v-alert>
-        <v-form v-if="form" v-model="valid" :disabled="disabled" ref="form">
+        <v-alert v-if="readonly" color="primary" outlined text>
+            AI settings are defined through the config and cannot be modified via the UI.
+        </v-alert>
+        <v-form v-if="form" v-model="valid" :disabled="disabled || readonly" ref="form">
             <div class="subtitle-1 mt-3">Model Provider</div>
             <v-radio-group v-model="form.provider" row dense class="mt-0" hide-details>
                 <v-radio value="anthropic">
@@ -94,7 +97,7 @@
                 {{ message }}
             </v-alert>
             <div class="mt-3 d-flex" style="gap: 8px">
-                <v-btn color="primary" @click="save" :disabled="disabled || !valid || !changed" :loading="loading">Save</v-btn>
+                <v-btn color="primary" @click="save" :disabled="disabled || readonly || !valid || !changed" :loading="loading">Save</v-btn>
             </div>
         </v-form>
     </div>
@@ -107,6 +110,7 @@ export default {
     data() {
         return {
             disabled: this.$coroot.edition !== 'Enterprise',
+            readonly: false,
             form: { provider: '', anthropic: {}, openai: {}, openai_compatible: {} },
             valid: false,
             loading: false,
@@ -135,6 +139,7 @@ export default {
                     this.error = error;
                     return;
                 }
+                this.readonly = data.readonly;
                 this.form.provider = data.provider;
                 this.form.anthropic = data.anthropic || {};
                 this.form.openai = data.openai || {};

--- a/front/src/views/Integrations.vue
+++ b/front/src/views/Integrations.vue
@@ -6,12 +6,15 @@
         <v-alert v-if="message" color="green" outlined text>
             {{ message }}
         </v-alert>
-        <v-form>
+        <v-alert v-if="readonly" color="primary" outlined text>
+            Notification settings are defined through the config and cannot be modified via the UI.
+        </v-alert>
+        <v-form :disabled="readonly">
             <div class="subtitle-1">Base url</div>
             <div class="caption">This URL is used for things like creating links in alerts.</div>
             <div class="d-flex">
                 <v-text-field v-model="form.base_url" :rules="[$validators.isUrl]" outlined dense />
-                <v-btn @click="save" color="primary" :loading="saving" class="ml-2" height="38">Save</v-btn>
+                <v-btn @click="save" color="primary" :loading="saving" :disabled="readonly" class="ml-2" height="38">Save</v-btn>
             </div>
         </v-form>
 
@@ -43,8 +46,12 @@
                     <td>
                         <v-btn v-if="!i.configured" small @click="open(i, 'new')" color="primary">Configure</v-btn>
                         <div v-else class="d-flex">
-                            <v-btn icon small @click="open(i, 'edit')"><v-icon small>mdi-pencil</v-icon></v-btn>
-                            <v-btn icon small @click="open(i, 'del')"><v-icon small>mdi-trash-can-outline</v-icon></v-btn>
+                            <v-btn icon small :disabled="readonly" @click="open(i, 'edit')">
+                                <v-icon small>mdi-pencil</v-icon>
+                            </v-btn>
+                            <v-btn icon small :disabled="readonly" @click="open(i, 'del')">
+                                <v-icon small>mdi-trash-can-outline</v-icon>
+                            </v-btn>
                         </div>
                     </td>
                 </tr>
@@ -70,6 +77,7 @@ export default {
             loading: false,
             error: '',
             message: '',
+            readonly: false,
             saving: false,
             form: {
                 base_url: '',
@@ -111,6 +119,7 @@ export default {
                     this.$api.saveIntegrations('', 'save', this.form, () => {});
                 }
                 this.integrations = data.integrations;
+                this.readonly = data.readonly;
             });
         },
         save() {

--- a/main.go
+++ b/main.go
@@ -44,9 +44,11 @@ func main() {
 	klog.Infof("edition: %s", Edition)
 	klog.Infof("version: %s", version)
 
-	cfg := config.Load()
+	cfg, err := config.Load()
+	if err != nil {
+		klog.Exitf("failed to load config: %s", err)
+	}
 
-	var err error
 	if err = utils.CreateDirectoryIfNotExists(cfg.DataDir); err != nil {
 		klog.Exitln(err)
 	}

--- a/model/custom_application.go
+++ b/model/custom_application.go
@@ -1,5 +1,5 @@
 package model
 
 type CustomApplication struct {
-	InstancePattens []string `json:"instance_pattens"`
+	InstancePatterns []string `json:"instance_patterns" yaml:"instancePatterns"`
 }

--- a/utils/url.go
+++ b/utils/url.go
@@ -13,8 +13,8 @@ import (
 )
 
 type Header struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Key   string `json:"key" yaml:"key"`
+	Value string `json:"value" yaml:"value"`
 }
 
 func (h Header) Valid() bool {
@@ -22,8 +22,8 @@ func (h Header) Valid() bool {
 }
 
 type BasicAuth struct {
-	User     string `json:"user"`
-	Password string `json:"password"`
+	User     string `json:"user" yaml:"username"`
+	Password string `json:"password" yaml:"password"`
 }
 
 func (ba *BasicAuth) AddTo(address string) (string, error) {


### PR DESCRIPTION
This PR extends project configuration capabilities via the config file.

In addition to API keys, the following settings can now be defined:
- Notification integrations (Slack, MS Teams, PagerDuty, Opsgenie, Webhook)
- Application categories (including their notification settings)
- Custom applications