### PR TITLE
config: enable environment variable substitution

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -202,6 +202,7 @@ func ReadFromFile() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	data = []byte(os.ExpandEnv(string(data)))
 	return data, nil
 }
 


### PR DESCRIPTION
This allows injecting secrets and other values from environment variables into the configuration.