### PR TITLE
fix: Check for empty strings for basic auth

### DIFF
--- a/notifications/webhook.go
+++ b/notifications/webhook.go
@@ -104,7 +104,7 @@ func (wh *Webhook) send(ctx context.Context, data []byte) error {
 	if err != nil {
 		return err
 	}
-	if wh.cfg.BasicAuth != nil {
+	if wh.cfg.BasicAuth != nil && wh.cfg.BasicAuth.User != "" && wh.cfg.BasicAuth.Password != "" {
 		req.SetBasicAuth(wh.cfg.BasicAuth.User, wh.cfg.BasicAuth.Password)
 	}
 	req.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
* Strings in golang are emtpy "" by default which can cause problems