### PR TITLE
fix helm error

### DIFF
--- a/docs/docs/installation/k8s-operator.md
+++ b/docs/docs/installation/k8s-operator.md
@@ -375,7 +375,7 @@ spec:
 #      apiKeySecret:  # Secret containing the API key.
 #        name: # Name of the secret to select from.
 #        key:  # Key of the secret to select from.
-#      baseUrl:  # Base URL (e.g., https://generativelanguage.googleapis.com/v1beta/openai).
+#      baseURL:  # Base URL (e.g., https://generativelanguage.googleapis.com/v1beta/openai).
 #      model:    # Model name (e.g., gemini-2.5-pro-preview-06-05).
 ```
 


### PR DESCRIPTION
if we use variable "spec.ai.openaiCompatible.baseUrl", we catching error "cannot patch "coroot" with kind Coroot: Coroot.coroot.com "coroot" is invalid: spec.ai.openaiCompatible.baseURL: Required value"