### PR TITLE
fix: should check ch not nil before ch.Close()

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -368,9 +368,7 @@ func (api *Api) Overview(w http.ResponseWriter, r *http.Request, u *db.User) {
 	if ch, err = api.GetClickhouseClient(project); err != nil {
 		klog.Warningln(err)
 	}
-	if ch != nil {
-		defer ch.Close()
-	}
+	defer ch.Close()
 	auditor.Audit(world, project, nil, project.ClickHouseConfig(api.globalClickHouse) != nil, nil)
 	utils.WriteJson(w, api.WithContext(project, cacheStatus, world, views.Overview(r.Context(), ch, world, view, r.URL.Query().Get("query"))))
 }
@@ -1313,9 +1311,7 @@ func (api *Api) Profiling(w http.ResponseWriter, r *http.Request, u *db.User) {
 		http.Error(w, "ClickHouse is not available", http.StatusInternalServerError)
 		return
 	}
-	if ch != nil {
-		defer ch.Close()
-	}
+	defer ch.Close()
 	q := r.URL.Query()
 	auditor.Audit(world, project, nil, project.ClickHouseConfig(api.globalClickHouse) != nil, nil)
 	utils.WriteJson(w, api.WithContext(project, cacheStatus, world, views.Profiling(r.Context(), ch, app, q, world.Ctx)))
@@ -1373,9 +1369,7 @@ func (api *Api) Tracing(w http.ResponseWriter, r *http.Request, u *db.User) {
 		http.Error(w, "ClickHouse is not available", http.StatusInternalServerError)
 		return
 	}
-	if ch != nil {
-		defer ch.Close()
-	}
+	defer ch.Close()
 	auditor.Audit(world, project, nil, project.ClickHouseConfig(api.globalClickHouse) != nil, nil)
 	utils.WriteJson(w, api.WithContext(project, cacheStatus, world, views.Tracing(r.Context(), ch, app, q, world)))
 }
@@ -1429,9 +1423,7 @@ func (api *Api) Logs(w http.ResponseWriter, r *http.Request, u *db.User) {
 	if chErr != nil {
 		klog.Warningln(chErr)
 	}
-	if ch != nil {
-		defer ch.Close()
-	}
+	defer ch.Close()
 	auditor.Audit(world, project, nil, project.ClickHouseConfig(api.globalClickHouse) != nil, nil)
 	q := r.URL.Query()
 	res := views.Logs(r.Context(), ch, app, q, world)

--- a/api/api.go
+++ b/api/api.go
@@ -368,7 +368,9 @@ func (api *Api) Overview(w http.ResponseWriter, r *http.Request, u *db.User) {
 	if ch, err = api.GetClickhouseClient(project); err != nil {
 		klog.Warningln(err)
 	}
-	defer ch.Close()
+	if ch != nil {
+		defer ch.Close()
+	}
 	auditor.Audit(world, project, nil, project.ClickHouseConfig(api.globalClickHouse) != nil, nil)
 	utils.WriteJson(w, api.WithContext(project, cacheStatus, world, views.Overview(r.Context(), ch, world, view, r.URL.Query().Get("query"))))
 }
@@ -1311,7 +1313,9 @@ func (api *Api) Profiling(w http.ResponseWriter, r *http.Request, u *db.User) {
 		http.Error(w, "ClickHouse is not available", http.StatusInternalServerError)
 		return
 	}
-	defer ch.Close()
+	if ch != nil {
+		defer ch.Close()
+	}
 	q := r.URL.Query()
 	auditor.Audit(world, project, nil, project.ClickHouseConfig(api.globalClickHouse) != nil, nil)
 	utils.WriteJson(w, api.WithContext(project, cacheStatus, world, views.Profiling(r.Context(), ch, app, q, world.Ctx)))
@@ -1369,7 +1373,9 @@ func (api *Api) Tracing(w http.ResponseWriter, r *http.Request, u *db.User) {
 		http.Error(w, "ClickHouse is not available", http.StatusInternalServerError)
 		return
 	}
-	defer ch.Close()
+	if ch != nil {
+		defer ch.Close()
+	}
 	auditor.Audit(world, project, nil, project.ClickHouseConfig(api.globalClickHouse) != nil, nil)
 	utils.WriteJson(w, api.WithContext(project, cacheStatus, world, views.Tracing(r.Context(), ch, app, q, world)))
 }
@@ -1423,7 +1429,9 @@ func (api *Api) Logs(w http.ResponseWriter, r *http.Request, u *db.User) {
 	if chErr != nil {
 		klog.Warningln(chErr)
 	}
-	defer ch.Close()
+	if ch != nil {
+		defer ch.Close()
+	}
 	auditor.Audit(world, project, nil, project.ClickHouseConfig(api.globalClickHouse) != nil, nil)
 	q := r.URL.Query()
 	res := views.Logs(r.Context(), ch, app, q, world)

--- a/clickhouse/clickhouse.go
+++ b/clickhouse/clickhouse.go
@@ -99,6 +99,9 @@ func (c *Client) QueryRow(ctx context.Context, query string, args ...interface{}
 }
 
 func (c *Client) Close() error {
+	if c == nil {
+		return nil
+	}
 	return c.conn.Close()
 }
 


### PR DESCRIPTION
Since upgrading to v1.13.0, the program has encountered a panic issue.

Here is the log where the issue occurred:
```
http: panic serving *****: runtime error: invalid memory address or nil pointer dereference
goroutine 261 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1947 +0xbe
panic({0x13b0be0?, 0x32729d0?})
	/usr/local/go/src/runtime/panic.go:792 +0x132
github.com/coroot/coroot/clickhouse.(*Client).Close(...)
	/tmp/src/clickhouse/clickhouse.go:102
github.com/coroot/coroot/api.(*Api).Overview(0xc001789ec0, {0x29ca278, 0xc007f58380}, 0xc007f7a000, 0xc007c97310)
	/tmp/src/api/api.go:374 +0xc3b
main.main.(*Api).Auth.func15({0x29ca278, 0xc007f58380}, 0xc007f7a000)
	/tmp/src/api/auth.go:76 +0x107
net/http.HandlerFunc.ServeHTTP(0x13d93c0?, {0x29ca278?, 0xc007f58380?}, 0x2c?)
	/usr/local/go/src/net/http/server.go:2294 +0x29
github.com/coroot/coroot/stats.(*Collector).MiddleWare-fm.(*Collector).MiddleWare.func1({0x29ca278, 0xc007f58380}, 0xc007f7a000)
	/tmp/src/stats/stats.go:236 +0x14a
net/http.HandlerFunc.ServeHTTP(0xc001db9e00?, {0x29ca278?, 0xc007f58380?}, 0x0?)
	/usr/local/go/src/net/http/server.go:2294 +0x29
github.com/gorilla/mux.(*Router).ServeHTTP(0xc00235c000, {0x29ca278, 0xc007f58380}, 0xc001db9b80)
	/go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0x1e2
net/http.serverHandler.ServeHTTP({0xc0073d67e0?}, {0x29ca278?, 0xc007f58380?}, 0x6?)
	/usr/local/go/src/net/http/server.go:3301 +0x8e
net/http.(*conn).serve(0xc0073fc480, {0x29ccff8, 0xc0023e3f20})
	/usr/local/go/src/net/http/server.go:2102 +0x625
created by net/http.(*Server).Serve in goroutine 1
	/usr/local/go/src/net/http/server.go:3454 +0x485
```

The specific reason is that api.GetClickhouseClient(...) returns nil and assigns it to ch, so calling ch.defer() will triggers a nil pointer dereference. 