### PR TITLE
feat: extend animated particles to application instance map

### DIFF
--- a/front/src/components/AppMap.vue
+++ b/front/src/components/AppMap.vue
@@ -223,32 +223,28 @@
                     :marker-start="a.markerStart ? `url(#marker-${a.status}-${a.hi(focused)})` : ''"
                     :marker-end="a.markerEnd ? `url(#marker-${a.status}-${a.hi(focused)})` : ''"
                 />
-                
+
                 <!-- Animated particles flowing along the connection -->
                 <g v-if="a._w && a._w > 0 && !a.internal" class="particle-group">
-                    <circle 
-                        v-for="(particle, index) in getParticles(a)" 
+                    <circle
+                        v-for="(particle, index) in getParticles(a)"
                         :key="`particle-appmap-${arrows.indexOf(a)}-${index}`"
-                        :r="getParticleSize(a._w)" 
+                        :r="getParticleSize(a._w)"
                         :class="`particle ${a.status}`"
                         :style="{ animationDelay: `${index * 0.4}s`, animationDuration: `${getAnimationDuration(a._w)}s` }"
                     >
-                        <animateMotion
-                            :dur="`${getAnimationDuration(a._w)}s`"
-                            :begin="`${index * 0.4}s`"
-                            repeatCount="indefinite"
-                        >
-                            <mpath :href="`#appmap-path-${arrows.indexOf(a)}`"/>
+                        <animateMotion :dur="`${getAnimationDuration(a._w)}s`" :begin="`${index * 0.4}s`" repeatCount="indefinite">
+                            <mpath :href="`#appmap-path-${arrows.indexOf(a)}`" />
                         </animateMotion>
                     </circle>
                 </g>
-                
+
                 <!-- Hidden path for animateMotion reference -->
-                <path 
+                <path
                     v-if="a._w && a._w > 0 && !a.internal"
-                    :id="`appmap-path-${arrows.indexOf(a)}`" 
-                    :d="a.d" 
-                    fill="none" 
+                    :id="`appmap-path-${arrows.indexOf(a)}`"
+                    :d="a.d"
+                    fill="none"
                     stroke="none"
                     style="visibility: hidden"
                 />
@@ -472,7 +468,9 @@ export default {
             // Number of particles based on connection weight/importance
             // Higher weight = more particles (max 3 particles for app map)
             const maxParticles = Math.min(3, Math.ceil(arrow._w / 15) || 1);
-            return Array(maxParticles).fill().map((_, i) => ({ id: i }));
+            return Array(maxParticles)
+                .fill()
+                .map((_, i) => ({ id: i }));
         },
         getParticleSize(weight) {
             // Particle size based on connection weight (1px to 3px for app map)
@@ -481,7 +479,7 @@ export default {
         getAnimationDuration(weight) {
             // Animation speed based on weight - higher weight = faster particles
             // Duration between 2-5 seconds (inverse relationship)
-            return Math.max(2, 5 - (weight / 20));
+            return Math.max(2, 5 - weight / 20);
         },
     },
 };

--- a/front/src/views/ServiceMap.vue
+++ b/front/src/views/ServiceMap.vue
@@ -55,35 +55,24 @@
                 <template v-for="a in arrows">
                     <path v-if="a.dd" :d="a.dd" class="arrow" :class="a.status" />
                     <path :d="a.d" class="arrow" :class="a.status" :stroke-opacity="a.hi ? 1 : 0.7" :marker-end="`url(#marker-${a.status})`" />
-                    
+
                     <!-- Animated particles flowing along the connection -->
                     <g v-if="a.w && a.w > 0" class="particle-group">
-                        <circle 
-                            v-for="(particle, index) in getParticles(a)" 
+                        <circle
+                            v-for="(particle, index) in getParticles(a)"
                             :key="`particle-${a.src}-${a.dst}-${index}`"
-                            :r="getParticleSize(a.w)" 
+                            :r="getParticleSize(a.w)"
                             :class="`particle ${a.status}`"
                             :style="{ animationDelay: `${index * 0.3}s`, animationDuration: `${getAnimationDuration(a.w)}s` }"
                         >
-                            <animateMotion
-                                :dur="`${getAnimationDuration(a.w)}s`"
-                                :begin="`${index * 0.3}s`"
-                                repeatCount="indefinite"
-                            >
-                                <mpath :href="`#path-${a.src}-${a.dst}`"/>
+                            <animateMotion :dur="`${getAnimationDuration(a.w)}s`" :begin="`${index * 0.3}s`" repeatCount="indefinite">
+                                <mpath :href="`#path-${a.src}-${a.dst}`" />
                             </animateMotion>
                         </circle>
                     </g>
-                    
+
                     <!-- Hidden path for animateMotion reference -->
-                    <path 
-                        v-if="a.w && a.w > 0"
-                        :id="`path-${a.src}-${a.dst}`" 
-                        :d="a.d" 
-                        fill="none" 
-                        stroke="none"
-                        style="visibility: hidden"
-                    />
+                    <path v-if="a.w && a.w > 0" :id="`path-${a.src}-${a.dst}`" :d="a.d" fill="none" stroke="none" style="visibility: hidden" />
                 </template>
             </svg>
             <template v-for="a in arrows">
@@ -335,7 +324,9 @@ export default {
             // Number of particles based on connection weight/importance
             // Higher weight = more particles (max 4 particles)
             const maxParticles = Math.min(4, Math.ceil(arrow.w / 10) || 1);
-            return Array(maxParticles).fill().map((_, i) => ({ id: i }));
+            return Array(maxParticles)
+                .fill()
+                .map((_, i) => ({ id: i }));
         },
         getParticleSize(weight) {
             // Particle size based on connection weight (1.5px to 4px)
@@ -344,7 +335,7 @@ export default {
         getAnimationDuration(weight) {
             // Animation speed based on weight - higher weight = faster particles
             // Duration between 2-6 seconds (inverse relationship)
-            return Math.max(2, 6 - (weight / 15));
+            return Math.max(2, 6 - weight / 15);
         },
     },
 };


### PR DESCRIPTION
- Add flowing particle animations to AppMap component (application instances page)
- Particles animate along connections between clients -> app -> dependencies
- Smaller, more subtle particles for app-specific view (1-3px vs 1.5-4px)
- Max 3 particles per connection (vs 4 in main service map)
- Only animates external connections (skips internal instance connections)
- Same color-coded particles matching connection health status
- Consistent animation timing and behavior with main ServiceMap