### PR TITLE
Document enhanced continuous profiling for JVM

### DIFF
--- a/docs/docs/inspections/jvm.md
+++ b/docs/docs/inspections/jvm.md
@@ -13,6 +13,6 @@ So, you don't need to configure anything!
 <img alt="JVM" src="/img/docs/jvm.png" class="card w-1200"/>
 
 # Enhanced continuous profiling
-For continuous profiling, Coroot uses eBPF as well, capturing execution paths at the kernel level with minimal overhead. However, because the JVM relies heavily on JIT compilation, the generated native code does not include symbolic information by default. In other words, we see memory addresses, but not the actual method names. To make the profiles readable and useful, the JVM needs to expose symbol information. This can be generated using the jcmd <pid> "Compiler.perfmap" command.
+For continuous profiling, Coroot uses eBPF as well, capturing execution paths at the kernel level with minimal overhead. However, because the JVM relies heavily on JIT compilation, the generated native code does not include symbolic information by default. In other words, we see memory addresses, but not the actual method names. To make the profiles readable and useful, the JVM needs to expose symbol information. This can be generated using the `jcmd <pid> Compiler.perfmap` command.
 
-Coroot automates this step by periodically calling jcmd in the background. However, the JVM must be started with the "-XX:+PreserveFramePointer" option. This allows for accurate stack traces and proper symbolization of JIT-compiled code, with only a small performance overhead (typically around 1-3%).
+Coroot automates this step by periodically calling jcmd in the background. However, the JVM must be started with the `-XX:+PreserveFramePointer` option. This allows for accurate stack traces and proper symbolization of JIT-compiled code, with only a small performance overhead (typically around 1-3%).


### PR DESCRIPTION
Added details about enhanced continuous profiling using eBPF and the need for JVM to expose symbol information for better profile readability.

This is only mentioned here: https://coroot.com/blog/troubleshooting-java-applications-with-coroot/