### PR TITLE
incidents: truncate long incident time ranges to 1 day when rendering SLI charts

### DIFF
--- a/api/rca.go
+++ b/api/rca.go
@@ -18,7 +18,7 @@ import (
 func (api *Api) RCA(w http.ResponseWriter, r *http.Request, u *db.User) {
 	rca := &model.RCA{}
 	projectId := db.ProjectId(mux.Vars(r)["project"])
-	from, to, incident := api.getTimeContext(r)
+	from, to, incident, _ := api.getTimeContext(r)
 
 	defer func() {
 		if incident != nil {

--- a/model/chart.go
+++ b/model/chart.go
@@ -114,6 +114,9 @@ type Chart struct {
 }
 
 func NewChart(ctx timeseries.Context, title string) *Chart {
+	if ctx.Truncated {
+		title += " (truncated range)"
+	}
 	return &Chart{Ctx: ctx, Title: title}
 }
 
@@ -245,6 +248,10 @@ type ChartGroup struct {
 }
 
 func NewChartGroup(ctx timeseries.Context, title string) *ChartGroup {
+	if ctx.Truncated {
+		title += " (truncated range)"
+		ctx.Truncated = false
+	}
 	return &ChartGroup{ctx: ctx, Title: title}
 }
 

--- a/timeseries/time.go
+++ b/timeseries/time.go
@@ -20,10 +20,11 @@ const (
 )
 
 type Context struct {
-	From    Time     `json:"from"`
-	To      Time     `json:"to"`
-	Step    Duration `json:"step"`
-	RawStep Duration `json:"raw_step"`
+	From      Time     `json:"from"`
+	To        Time     `json:"to"`
+	Step      Duration `json:"step"`
+	RawStep   Duration `json:"raw_step"`
+	Truncated bool     `json:"truncated"`
 }
 
 func NewContext(from, to Time, step Duration) Context {


### PR DESCRIPTION
Fixes #753 