### PR TITLE
truncate long alert detail values to prevent Slack invalid_attachments error

### DIFF
--- a/watchers/alerts.go
+++ b/watchers/alerts.go
@@ -25,6 +25,16 @@ import (
 	"k8s.io/klog"
 )
 
+const alertDetailValueMaxLen = 1000
+
+func truncateValue(s string) string {
+	runes := []rune(s)
+	if len(runes) <= alertDetailValueMaxLen {
+		return s
+	}
+	return string(runes[:alertDetailValueMaxLen]) + "…"
+}
+
 type LogPatternEvaluation struct {
 	ShouldAlert bool
 	Explanation string
@@ -314,7 +324,7 @@ func (w *Alerts) evaluateLogPatternAlerts(project *db.Project, rule *model.Alert
 							updatedDetails = append(updatedDetails, model.AlertDetail{Name: "Description", Value: rule.Templates.Description})
 						}
 						if lp.Sample != "" {
-							updatedDetails = append(updatedDetails, model.AlertDetail{Name: "Sample", Value: lp.Sample, Code: true})
+							updatedDetails = append(updatedDetails, model.AlertDetail{Name: "Sample", Value: truncateValue(lp.Sample), Code: true})
 						}
 						// preserve existing AI analysis
 						for _, d := range blockingAlert.Details {
@@ -355,7 +365,7 @@ func (w *Alerts) evaluateLogPatternAlerts(project *db.Project, rule *model.Alert
 					logDetails = append(logDetails, model.AlertDetail{Name: "Description", Value: rule.Templates.Description})
 				}
 				if lp.Sample != "" {
-					logDetails = append(logDetails, model.AlertDetail{Name: "Sample", Value: lp.Sample, Code: true})
+					logDetails = append(logDetails, model.AlertDetail{Name: "Sample", Value: truncateValue(lp.Sample), Code: true})
 				}
 				if aiExplanation != "" {
 					logDetails = append(logDetails, model.AlertDetail{Name: "AI analysis", Value: aiExplanation})
@@ -476,7 +486,7 @@ func (w *Alerts) evaluatePromQLAlerts(project *db.Project, rule *model.AlertingR
 				parts = append(parts, fmt.Sprintf(`%s="%s"`, k, v))
 			}
 			sort.Strings(parts)
-			details = append(details, model.AlertDetail{Name: "Labels", Value: strings.Join(parts, "\n"), Code: true})
+			details = append(details, model.AlertDetail{Name: "Labels", Value: truncateValue(strings.Join(parts, "\n")), Code: true})
 			if q, err := prom.AddExtraSelector(rule.Source.PromQL.Expression, "{"+strings.Join(parts, ",")+"}"); err == nil {
 				scopedQuery = q
 			}
@@ -772,7 +782,7 @@ func (w *Alerts) evaluateKubernetesEventsAlerts(project *db.Project, rule *model
 		}
 		sort.Strings(labelParts)
 		if g.events[0].Body != "" {
-			details = append(details, model.AlertDetail{Name: "Event message", Value: g.events[0].Body, Code: true})
+			details = append(details, model.AlertDetail{Name: "Event message", Value: truncateValue(g.events[0].Body), Code: true})
 		}
 		details = append(details, model.AlertDetail{Name: "Labels", Value: strings.Join(labelParts, "\n"), Code: true})
 		if queryJSON, err := json.Marshal(queryFilters); err == nil {
@@ -908,7 +918,7 @@ func (w *Alerts) initLogPatternAlerts(project *db.Project, rule *model.AlertingR
 					initDetails = append(initDetails, model.AlertDetail{Name: "Description", Value: rule.Templates.Description})
 				}
 				if lp.Sample != "" {
-					initDetails = append(initDetails, model.AlertDetail{Name: "Sample", Value: lp.Sample, Code: true})
+					initDetails = append(initDetails, model.AlertDetail{Name: "Sample", Value: truncateValue(lp.Sample), Code: true})
 				}
 				alert := &model.Alert{
 					Id:                  utils.NanoId(12),


### PR DESCRIPTION
Fixes #822 