### PR TITLE
api: expose project ID in available_projects response

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -242,13 +242,17 @@ func (api *Api) Project(w http.ResponseWriter, r *http.Request, u *db.User) {
 
 	switch r.Method {
 	case http.MethodGet:
+		type AvailableProject struct {
+			Id   string `json:"id"`
+			Name string `json:"name"`
+		}
 		type ProjectSettings struct {
 			Readonly          bool                `json:"readonly"`
 			Name              string              `json:"name"`
 			ApiKeys           any                 `json:"api_keys"`
 			RefreshInterval   timeseries.Duration `json:"refresh_interval"`
 			MemberProjects    []string            `json:"member_projects,omitempty"`
-			AvailableProjects []string            `json:"available_projects,omitempty"`
+			AvailableProjects []AvailableProject  `json:"available_projects,omitempty"`
 		}
 		projects, err := api.db.GetProjects()
 		if err != nil {
@@ -259,7 +263,7 @@ func (api *Api) Project(w http.ResponseWriter, r *http.Request, u *db.User) {
 		res := ProjectSettings{}
 		for _, p := range projects {
 			if p.Id != db.ProjectId(projectId) && !p.Multicluster() {
-				res.AvailableProjects = append(res.AvailableProjects, p.Name)
+				res.AvailableProjects = append(res.AvailableProjects, AvailableProject{Id: string(p.Id), Name: p.Name})
 			}
 		}
 		if projectId != "" {

--- a/front/src/views/Project.vue
+++ b/front/src/views/Project.vue
@@ -35,6 +35,8 @@
 
                     <v-autocomplete
                         :items="availableProjects"
+                        item-text="name"
+                        item-value="id"
                         v-model="form.member_projects"
                         color="primary"
                         multiple


### PR DESCRIPTION
## Summary
- Change `available_projects` from string array (names only) to object array with both `id` and `name` fields
- Allows API consumers to discover project IDs programmatically without direct DB access

## Before
```json
{"available_projects": ["default"]}
```

## After
```json
{"available_projects": [{"id": "f9ud92ea", "name": "default"}]}
```

## Motivation
When building integrations that consume the Coroot API (e.g., MCP tool servers for AI-assisted observability), the project ID is required for all `/api/project/{project}/...` endpoints. Currently, the only way to obtain the project ID is through the browser URL or direct database access, as the API only exposes project names.

This change makes it possible to programmatically discover project IDs via the existing `/api/project/` endpoint.