### PR TITLE
update docs with new --ca-file flag

### DIFF
--- a/docs/docs/configuration/coroot-cluster-agent.md
+++ b/docs/docs/configuration/coroot-cluster-agent.md
@@ -25,6 +25,7 @@ You can configure coroot-cluster-agent using command-line flags or environment v
 | `--profiles-scrape-timeout` | `PROFILES_SCRAPE_TIMEOUT` | `10s` | Timeout for profiling scrape requests |
 | `--kube-state-metrics-listen-address` | `KUBE_STATE_METRICS_LISTEN_ADDRESS` | `127.0.0.1:10303` | Listen address for the kube-state-metrics endpoint |
 | `--insecure-skip-verify` | `INSECURE_SKIP_VERIFY` | `false` | Skip TLS certificate verification |
+| `--ca-file` | `CA_FILE` | – | Path to the custom CA certificate file |
 | `--collect-kubernetes-events` | `COLLECT_KUBERNETES_EVENTS` | `true` | Collect and forward Kubernetes events |
 | `--track-database-changes` | `TRACK_DATABASE_CHANGES` | `true` | Track schema and settings changes in databases |
 | `--track-database-sizes` | `TRACK_DATABASE_SIZES` | `true` | Collect per-database and per-table size metrics |

--- a/docs/docs/configuration/coroot-node-agent.md
+++ b/docs/docs/configuration/coroot-node-agent.md
@@ -51,6 +51,7 @@ You can configure coroot-node-agent using command-line flags or environment vari
 | `--logs-endpoint` | `LOGS_ENDPOINT` | – | Custom URL for logs export |
 | `--profiles-endpoint` | `PROFILES_ENDPOINT` | – | Custom URL for profiles export |
 | `--insecure-skip-verify` | `INSECURE_SKIP_VERIFY` | `false` | Skip TLS certificate verification |
+| `--ca-file` | `CA_FILE` | – | Path to the custom CA certificate file |
 | `--scrape-interval` | `SCRAPE_INTERVAL` | `15s` | How often to collect internal metrics |
 | `--wal-dir` | `WAL_DIR` | `/tmp/coroot-node-agent` | Directory for WAL storage |
 | `--max-spool-size` | `MAX_SPOOL_SIZE` | `500MB` | Max size for on-disk spool |


### PR DESCRIPTION
Update Docs with new flag that supports TLS certificate verification by node-agent and cluster-agent.

Related MR's
- https://github.com/coroot/coroot-cluster-agent/pull/22
- https://github.com/coroot/coroot-node-agent/pull/299