### PR TITLE
feat: add container-level profiling filter

### DIFF
--- a/api/views/profiling/profiling.go
+++ b/api/views/profiling/profiling.go
@@ -16,13 +16,14 @@ import (
 )
 
 type View struct {
-	Status    model.Status   `json:"status"`
-	Message   string         `json:"message"`
-	Services  []Service      `json:"services"`
-	Profiles  []Meta         `json:"profiles"`
-	Profile   *model.Profile `json:"profile"`
-	Chart     *model.Chart   `json:"chart"`
-	Instances []string       `json:"instances"`
+	Status     model.Status        `json:"status"`
+	Message    string              `json:"message"`
+	Services   []Service           `json:"services"`
+	Profiles   []Meta              `json:"profiles"`
+	Profile    *model.Profile      `json:"profile"`
+	Chart      *model.Chart        `json:"chart"`
+	Instances  []string            `json:"instances"`
+	Containers map[string][]string `json:"containers,omitempty"`
 }
 
 type Service struct {
@@ -36,11 +37,12 @@ type Meta struct {
 }
 
 type Query struct {
-	Type     model.ProfileType `json:"type"`
-	From     timeseries.Time   `json:"from"`
-	To       timeseries.Time   `json:"to"`
-	Mode     string            `json:"mode"`
-	Instance string            `json:"instance"`
+	Type      model.ProfileType `json:"type"`
+	From      timeseries.Time   `json:"from"`
+	To        timeseries.Time   `json:"to"`
+	Mode      string            `json:"mode"`
+	Instance  string            `json:"instance"`
+	Container string            `json:"container"`
 }
 
 func Render(ctx context.Context, ch *clickhouse.Client, app *model.Application, query url.Values, w *model.World) *View {
@@ -148,6 +150,7 @@ func Render(ctx context.Context, ch *clickhouse.Client, app *model.Application, 
 	v.Chart = chart
 	v.Instances = maps.Keys(containers)
 	sort.Strings(v.Instances)
+	v.Containers = containers
 	v.Profile = &model.Profile{Type: q.Type, Diff: q.Mode == "diff"}
 	pq := clickhouse.ProfileQuery{
 		Type:     q.Type,
@@ -156,7 +159,10 @@ func Render(ctx context.Context, ch *clickhouse.Client, app *model.Application, 
 		Diff:     v.Profile.Diff,
 		Services: maps.Keys(services),
 	}
-	if q.Instance != "" {
+	if q.Container != "" {
+		// Filter by specific container ID
+		pq.Containers = []string{q.Container}
+	} else if q.Instance != "" {
 		if model.Profiles[q.Type].NodeAgent {
 			pq.Containers = containers[q.Instance]
 		} else {


### PR DESCRIPTION
## Summary

Add `container` query parameter to the profiling API to enable filtering eBPF CPU profiles by individual container ID.

## Problem

Currently, profiling can only be filtered by `instance` (pod name), which aggregates all containers within a pod. For pods running multiple containers (e.g. sidecar patterns, multi-process StatefulSets), there's no way to get a per-container flamegraph.

## Solution

- Add `Container` field to the profiling `Query` struct
- When `container` is specified, use it as the sole filter for the ClickHouse query (`Labels['container.id']`)
- When omitted, existing behavior is preserved (all containers in the instance)
- Add `Containers` map to the `View` response (instance → container ID list) so API clients can discover available container IDs

## API Usage

```
# Existing (unchanged)
GET /api/project/{id}/app/{app}/profiling?query={"from":...,"to":...}

# New: filter by container
GET /api/project/{id}/app/{app}/profiling?query={"from":...,"to":...,"container":"/k8s/ns/pod/container-name"}
```

The `containers` field in the response provides the mapping:
```json
{
  "instances": ["pod-name-0"],
  "containers": {
    "pod-name-0": ["/k8s/ns/pod-name-0/container-a", "/k8s/ns/pod-name-0/container-b"]
  }
}
```

## Testing

Tested on a production-like environment with StatefulSet pods containing 10 containers each:
- Without `container`: `total_ns=46.95s` (all containers aggregated)
- With `container` (single): `total_ns=3.37s` (one container only)

No schema changes needed — ClickHouse profiles table already stores `Labels['container.id']`.

Backward compatible: omitting `container` preserves existing behavior.