### PR TITLE
UI Enhancement: Add UI select all namespaces checkbox in Applications tab

### DIFF
--- a/front/src/components/ApplicationFilter.vue
+++ b/front/src/components/ApplicationFilter.vue
@@ -44,6 +44,19 @@
                         <span :title="item.text">{{ item.name }}</span>
                     </v-chip>
                 </template>
+                <template #prepend-item>
+                    <v-list-item ripple @click="toggleAllNamespaces">
+                        <v-list-item-action>
+                            <v-icon :color="selectedNamespaces.length > 0 ? 'primary' : ''">
+                                {{ selectAllIcon }}
+                            </v-icon>
+                        </v-list-item-action>
+                        <v-list-item-content>
+                            <v-list-item-title>Select All</v-list-item-title>
+                        </v-list-item-content>
+                    </v-list-item>
+                    <v-divider class="mt-2" />
+                </template>
             </v-autocomplete>
         </div>
 
@@ -158,6 +171,17 @@ export default {
         namespacesDisabled() {
             return !!this.search;
         },
+        allNamespacesSelected() {
+            return this.namespaces.length > 0 && this.selectedNamespaces.length === this.namespaces.length;
+        },
+        someNamespacesSelected() {
+            return this.selectedNamespaces.length > 0 && !this.allNamespacesSelected;
+        },
+        selectAllIcon() {
+            if (this.allNamespacesSelected) return 'mdi-checkbox-marked';
+            if (this.someNamespacesSelected) return 'mdi-minus-box';
+            return 'mdi-checkbox-blank-outline';
+        },
         filter() {
             const selectedCategories = new Set(this.selectedCategories);
             const selectedNamespaces = new Set(this.selectedNamespaces);
@@ -217,6 +241,13 @@ export default {
             const i = this.selectedNamespaces.indexOf(ns);
             if (i >= 0) {
                 this.selectedNamespaces.splice(i, 1);
+            }
+        },
+        toggleAllNamespaces() {
+            if (this.allNamespacesSelected) {
+                this.selectedNamespaces = [];
+            } else {
+                this.selectedNamespaces = this.namespaces.map((ns) => ns.value);
             }
         },
         load() {

--- a/front/src/components/FluxCD.vue
+++ b/front/src/components/FluxCD.vue
@@ -96,6 +96,19 @@
                                 <span>{{ item.name }}</span>
                             </v-chip>
                         </template>
+                        <template #prepend-item>
+                            <v-list-item ripple @click="toggleAllNamespaces">
+                                <v-list-item-action>
+                                    <v-icon :color="selectedNamespaces.length > 0 ? 'primary' : ''">
+                                        {{ selectAllIcon }}
+                                    </v-icon>
+                                </v-list-item-action>
+                                <v-list-item-content>
+                                    <v-list-item-title>Select All</v-list-item-title>
+                                </v-list-item-content>
+                            </v-list-item>
+                            <v-divider class="mt-2" />
+                        </template>
                     </v-autocomplete>
                 </div>
 
@@ -287,6 +300,17 @@ export default {
         availableNamespaces() {
             return this.selectedResourceType ? this.extractNamespaces(this.getResourcesOfType(this.selectedResourceType)) : [];
         },
+        allNamespacesSelected() {
+            return this.namespacesForSelect.length > 0 && this.selectedNamespaces.length === this.namespacesForSelect.length;
+        },
+        someNamespacesSelected() {
+            return this.selectedNamespaces.length > 0 && !this.allNamespacesSelected;
+        },
+        selectAllIcon() {
+            if (this.allNamespacesSelected) return 'mdi-checkbox-marked';
+            if (this.someNamespacesSelected) return 'mdi-minus-box';
+            return 'mdi-checkbox-blank-outline';
+        },
         namespacesForSelect() {
             if (!this.selectedResourceType) return [];
             return this.createNamespaceOptions(this.getResourcesOfType(this.selectedResourceType));
@@ -409,6 +433,13 @@ export default {
         removeNamespace(ns) {
             const index = this.selectedNamespaces.indexOf(ns);
             if (index >= 0) this.selectedNamespaces.splice(index, 1);
+        },
+        toggleAllNamespaces() {
+            if (this.allNamespacesSelected) {
+                this.selectedNamespaces = [];
+            } else {
+                this.selectedNamespaces = this.namespacesForSelect.map((ns) => ns.value);
+            }
         },
         getFluxResourceDrilldownLink(resourceId) {
             const resourceInfo = this.$utils.appId(resourceId);


### PR DESCRIPTION
At present, there is no select all checkbox. To view all namespaces, we need to select individually. This will be useful particularly in applications tab to select all apps in all namespaces