### PR TITLE
fix(logs): use indexed ServiceName column for k8s events queries

### DIFF
--- a/clickhouse/logs.go
+++ b/clickhouse/logs.go
@@ -276,6 +276,30 @@ func (q LogQuery) filters(attr *string) ([]string, []any) {
 				*f = append(*f, fmt.Sprintf(expr, v))
 				args = append(args, clickhouse.Named(v, a.Value))
 			}
+		case "service.name":
+			for j, a := range attrs {
+				var f *[]string
+				var expr string
+				switch a.Op {
+				case "=":
+					expr = "ServiceName = @%[1]s"
+					f = &ors
+				case "!=":
+					expr = "ServiceName != @%[1]s"
+					f = &ands
+				case "~":
+					expr = "match(ServiceName, @%[1]s)"
+					f = &ors
+				case "!~":
+					expr = "NOT match(ServiceName, @%[1]s)"
+					f = &ands
+				default:
+					continue
+				}
+				v := fmt.Sprintf("service_name_%d_%d", i, j)
+				*f = append(*f, fmt.Sprintf(expr, v))
+				args = append(args, clickhouse.Named(v, a.Value))
+			}
 		default:
 			for j, a := range attrs {
 				var f *[]string


### PR DESCRIPTION
The `/kubernetes` overview's severity histogram times out on windows greater than ~12 h. On a cluster with 1.28 M `KubernetesEvents` rows over 7 days. (5 days ago, 1.2M events burst)

`otel_logs` is sorted by `ServiceName`:

```
ORDER BY (ServiceName, SeverityText, toUnixTimestamp(Timestamp), TraceId)
```

but `service.name` filters fall through the default branch of `LogQuery.filters()`, rendering as Map lookups:

```
((LogAttributes['service.name'] = 'KubernetesEvents'
  OR ResourceAttributes['service.name'] = 'KubernetesEvents'))
```

The primary key can't bind. The Map bloom skip-indexes don't narrow either, so ClickHouse reads matched granules and verifies the predicate per row.

This patch adds a `case "service.name":` to the filter renderer so the same filter emits `ServiceName <op> @...` directly.

#### Numbers

Same `count()` two ways, same data:

| window | rows | indexed | maps   | speedup |
|--------|-----:|--------:|-------:|--------:|
| 1h     |  355 |    4 ms |  30 ms |    7.5× |
| 6h     | 2023 |    5 ms | 146 ms |   29.2× |
| 12h    | 4364 |    9 ms | 302 ms |   33.6× |

Row counts match.

#### EXPLAIN indexes=1

Indexed:

```
EXPLAIN indexes=1
SELECT count() FROM otel_logs
WHERE ServiceName = 'KubernetesEvents'
  AND Timestamp > now() - INTERVAL 1 DAY;

PrimaryKey
  Keys: ServiceName, toUnixTimestamp(Timestamp)
  Granules: 10 / 2060
```

Maps:

```
EXPLAIN indexes=1
SELECT count() FROM otel_logs
WHERE (LogAttributes['service.name'] = 'KubernetesEvents'
    OR ResourceAttributes['service.name'] = 'KubernetesEvents')
  AND Timestamp > now() - INTERVAL 1 DAY;

PrimaryKey
  Keys: toUnixTimestamp(Timestamp)
  Granules: 335 / 2060
Skip idx_log_attr_key      335 / 335   -- doesn't narrow
Skip idx_res_attr_key      335 / 335
Skip idx_log_attr_value    335 / 335
Skip idx_res_attr_value    335 / 335
```

After the patch the same view loads instantly.
