### PR TITLE
Surface GPU utilization and occupancy in node views

### DIFF
--- a/api/views/overview/nodes.go
+++ b/api/views/overview/nodes.go
@@ -2,6 +2,7 @@ package overview
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -15,6 +16,22 @@ import (
 type NetworkBandWidth struct {
 	Rx int `json:"rx"`
 	Tx int `json:"tx"`
+}
+
+type GPU struct {
+	UUID                           string   `json:"uuid"`
+	Name                           string   `json:"name"`
+	DriverVersion                  string   `json:"driver_version"`
+	TotalMemoryBytes               *int64   `json:"total_memory_bytes,omitempty"`
+	UsedMemoryBytes                *int64   `json:"used_memory_bytes,omitempty"`
+	UsageAveragePercent            *float32 `json:"usage_average_percent,omitempty"`
+	UsagePeakPercent               *float32 `json:"usage_peak_percent,omitempty"`
+	MemoryUsageAveragePercent      *float32 `json:"memory_usage_average_percent,omitempty"`
+	MemoryUsagePeakPercent         *float32 `json:"memory_usage_peak_percent,omitempty"`
+	ComputeOccupancyAveragePercent *float32 `json:"compute_occupancy_average_percent,omitempty"`
+	ComputeOccupancyPeakPercent    *float32 `json:"compute_occupancy_peak_percent,omitempty"`
+	TemperatureCelsius             *float32 `json:"temperature_celsius,omitempty"`
+	PowerWatts                     *float32 `json:"power_watts,omitempty"`
 }
 
 type Node struct {
@@ -33,6 +50,7 @@ type Node struct {
 	CPUPercent            int               `json:"cpu_percent"`
 	MemoryPercent         int               `json:"memory_percent"`
 	GPUs                  int               `json:"gpus"`
+	GPUStats              []GPU             `json:"gpu_stats,omitempty"`
 	TotalNetworkBandWidth int               `json:"total_network_band_width"`
 	NetworkBandwidth      *NetworkBandWidth `json:"network_bandwidth"`
 }
@@ -55,6 +73,7 @@ func RenderNodes(w *model.World, project *db.Project) []Node {
 			InstanceType:  n.InstanceType.Value(),
 			Compute:       compute(n),
 			GPUs:          len(n.GPUs),
+			GPUStats:      renderGPUs(n),
 			CloudProvider: strings.ToLower(n.CloudProvider.Value()),
 		}
 		switch {
@@ -110,6 +129,54 @@ func RenderNodes(w *model.World, project *db.Project) []Node {
 		nodes = append(nodes, node)
 	}
 	return nodes
+}
+
+func renderGPUs(n *model.Node) []GPU {
+	if len(n.GPUs) == 0 {
+		return nil
+	}
+	res := make([]GPU, 0, len(n.GPUs))
+	for _, gpu := range n.GPUs {
+		res = append(res, GPU{
+			UUID:                           gpu.UUID,
+			Name:                           gpu.Name.Value(),
+			DriverVersion:                  gpu.DriverVersion.Value(),
+			TotalMemoryBytes:               lastInt64(gpu.TotalMemory),
+			UsedMemoryBytes:                lastInt64(gpu.UsedMemory),
+			UsageAveragePercent:            lastFloat32(gpu.UsageAverage),
+			UsagePeakPercent:               lastFloat32(gpu.UsagePeak),
+			MemoryUsageAveragePercent:      lastFloat32(gpu.MemoryUsageAverage),
+			MemoryUsagePeakPercent:         lastFloat32(gpu.MemoryUsagePeak),
+			ComputeOccupancyAveragePercent: lastFloat32(gpu.ComputeOccupancyAverage),
+			ComputeOccupancyPeakPercent:    lastFloat32(gpu.ComputeOccupancyPeak),
+			TemperatureCelsius:             lastFloat32(gpu.Temperature),
+			PowerWatts:                     lastFloat32(gpu.PowerWatts),
+		})
+	}
+	sort.Slice(res, func(i, j int) bool {
+		if res[i].Name != res[j].Name {
+			return res[i].Name < res[j].Name
+		}
+		return res[i].UUID < res[j].UUID
+	})
+	return res
+}
+
+func lastFloat32(ts *timeseries.TimeSeries) *float32 {
+	v := ts.Last()
+	if timeseries.IsNaN(v) {
+		return nil
+	}
+	return &v
+}
+
+func lastInt64(ts *timeseries.TimeSeries) *int64 {
+	v := ts.Last()
+	if timeseries.IsNaN(v) {
+		return nil
+	}
+	res := int64(v)
+	return &res
 }
 
 func compute(n *model.Node) string {

--- a/auditor/gpu.go
+++ b/auditor/gpu.go
@@ -80,6 +80,18 @@ func (a *appAuditor) gpu() {
 			GetOrCreateChartGroup("GPU utilization <selector>, %", nil).
 			GetOrCreateChart("peak").
 			AddSeries(uuid, gi.gpu.UsagePeak)
+		if !gi.gpu.ComputeOccupancyAverage.IsEmpty() {
+			report.
+				GetOrCreateChartGroup("GPU compute occupancy <selector>, %", nil).
+				GetOrCreateChart("average").
+				AddSeries(uuid, gi.gpu.ComputeOccupancyAverage).Feature()
+		}
+		if !gi.gpu.ComputeOccupancyPeak.IsEmpty() {
+			report.
+				GetOrCreateChartGroup("GPU compute occupancy <selector>, %", nil).
+				GetOrCreateChart("peak").
+				AddSeries(uuid, gi.gpu.ComputeOccupancyPeak)
+		}
 		report.
 			GetOrCreateChartGroup("GPU Memory utilization <selector>, %", nil).
 			GetOrCreateChart("average").

--- a/auditor/node.go
+++ b/auditor/node.go
@@ -212,6 +212,18 @@ func AuditNode(w *model.World, node *model.Node) *model.AuditReport {
 			GetOrCreateChartGroup("GPU utilization <selector>, %", nil).
 			GetOrCreateChart("peak").
 			AddSeries(gpu.UUID, gpu.UsagePeak)
+		if !gpu.ComputeOccupancyAverage.IsEmpty() {
+			report.
+				GetOrCreateChartGroup("GPU compute occupancy <selector>, %", nil).
+				GetOrCreateChart("average").
+				AddSeries(gpu.UUID, gpu.ComputeOccupancyAverage).Feature()
+		}
+		if !gpu.ComputeOccupancyPeak.IsEmpty() {
+			report.
+				GetOrCreateChartGroup("GPU compute occupancy <selector>, %", nil).
+				GetOrCreateChart("peak").
+				AddSeries(gpu.UUID, gpu.ComputeOccupancyPeak)
+		}
 		report.
 			GetOrCreateChartGroup("GPU Memory utilization <selector>, %", nil).
 			GetOrCreateChart("average").

--- a/constructor/nodes.go
+++ b/constructor/nodes.go
@@ -208,5 +208,9 @@ func nodeGPU(node *model.Node, queryName string, m *model.MetricValues) {
 		gpu.UsageAverage = merge(gpu.UsageAverage, m.Values, timeseries.Any)
 	case "node_gpu_utilization_percent_peak":
 		gpu.UsagePeak = merge(gpu.UsagePeak, m.Values, timeseries.Any)
+	case "node_gpu_compute_occupancy_percent_avg":
+		gpu.ComputeOccupancyAverage = merge(gpu.ComputeOccupancyAverage, m.Values, timeseries.Any)
+	case "node_gpu_compute_occupancy_percent_peak":
+		gpu.ComputeOccupancyPeak = merge(gpu.ComputeOccupancyPeak, m.Values, timeseries.Any)
 	}
 }

--- a/constructor/queries.go
+++ b/constructor/queries.go
@@ -164,6 +164,8 @@ var QUERIES = []Query{
 	Q("node_gpu_memory_utilization_percent_peak", `node_resources_gpu_memory_utilization_percent_peak`, "gpu_uuid"),
 	Q("node_gpu_utilization_percent_avg", `node_resources_gpu_utilization_percent_avg`, "gpu_uuid"),
 	Q("node_gpu_utilization_percent_peak", `node_resources_gpu_utilization_percent_peak`, "gpu_uuid"),
+	Q("node_gpu_compute_occupancy_percent_avg", `node_resources_gpu_compute_occupancy_percent_avg`, "gpu_uuid"),
+	Q("node_gpu_compute_occupancy_percent_peak", `node_resources_gpu_compute_occupancy_percent_peak`, "gpu_uuid"),
 	Q("node_gpu_temperature_celsius", `node_resources_gpu_temperature_celsius`, "gpu_uuid"),
 	Q("node_gpu_power_usage_watts", `node_resources_gpu_power_usage_watts`, "gpu_uuid"),
 

--- a/docs/docs/configuration/coroot-node-agent.md
+++ b/docs/docs/configuration/coroot-node-agent.md
@@ -25,7 +25,7 @@ You can configure coroot-node-agent using command-line flags or environment vari
 | `--disable-log-parsing` | `DISABLE_LOG_PARSING` | `false` | Disable container log parsing |
 | `--disable-pinger` | `DISABLE_PINGER` | `false` | Disable ICMP ping to upstreams |
 | `--disable-l7-tracing` | `DISABLE_L7_TRACING` | `false` | Disable application-layer (L7) tracing |
-| `--disable-gpu-monitoring` | `DISABLE_GPU_MONITORING` | `false` | Disable GPU monitoring (NVML) |
+| `--disable-gpu-monitoring` | `DISABLE_GPU_MONITORING` | `false` | Disable GPU monitoring (NVML and Nsight Systems GPU metrics) |
 | `--enable-java-tls` | `ENABLE_JAVA_TLS` | `false` | Enable Java TLS instrumentation via dynamic agent loading |
 | `--enable-java-async-profiler` | `ENABLE_JAVA_ASYNC_PROFILER` | `false` | Enable Java profiling via async-profiler (CPU, memory allocations, lock contention) |
 | `--go-heap-profiler` | `GO_HEAP_PROFILER` | `enabled` | Go heap profiling mode: `disabled`, `enabled` (passive), or `force` (enable profiling in all Go apps) |

--- a/docs/docs/metrics/node-agent.md
+++ b/docs/docs/metrics/node-agent.md
@@ -115,6 +115,8 @@ Each container metric has the `container_id` label. This is a compound identifie
 
 ## GPU
 
+When `nsys` is available and Nsight Systems reports supported GPU metrics, node-agent automatically uses Nsight Systems GPU Metrics for node-level GPU utilization and DRAM bandwidth utilization. If Nsight Systems is unavailable, node-agent falls back to NVML sampling.
+
 ### container_resources_gpu_usage_percent
 * **Description**: Percent of GPU compute resources used by the container
 * **Type**: Gauge
@@ -673,21 +675,25 @@ E.g., if the derivative of this metric for a minute interval is 60s, this means 
 ### node_resources_gpu_memory_utilization_percent_avg
 * **Description**: Average GPU memory utilization (percentage) over the collection interval
 * **Type**: Gauge
+* **Source**: NVIDIA Nsight Systems GPU Metrics (DRAM read/write bandwidth) when available; otherwise NVIDIA Management Library (NVML)
 * **Labels**: gpu_uuid
 
 ### node_resources_gpu_memory_utilization_percent_peak
 * **Description**: Peak GPU memory utilization (percentage) over the collection interval
 * **Type**: Gauge
+* **Source**: NVIDIA Nsight Systems GPU Metrics (DRAM read/write bandwidth) when available; otherwise NVIDIA Management Library (NVML)
 * **Labels**: gpu_uuid
 
 ### node_resources_gpu_utilization_percent_avg
 * **Description**: Average GPU core utilization (percentage) over the collection interval
 * **Type**: Gauge
+* **Source**: NVIDIA Nsight Systems GPU Metrics (GR Active) when available; otherwise NVIDIA Management Library (NVML)
 * **Labels**: gpu_uuid
 
 ### node_resources_gpu_utilization_percent_peak
 * **Description**: Peak GPU core utilization (percentage) over the collection interval
 * **Type**: Gauge
+* **Source**: NVIDIA Nsight Systems GPU Metrics (GR Active) when available; otherwise NVIDIA Management Library (NVML)
 * **Labels**: gpu_uuid
 
 ### node_resources_gpu_temperature_celsius

--- a/front/src/views/Nodes.vue
+++ b/front/src/views/Nodes.vue
@@ -54,7 +54,29 @@
             </template>
 
             <template #item.gpus="{ item }">
-                <span v-if="item.gpus">{{ item.gpus }}</span>
+                <div v-if="item.gpus" class="gpu-cell">
+                    <template v-if="item.gpu_stats && item.gpu_stats.length">
+                        <div v-for="gpu in item.gpu_stats" :key="gpu.uuid" class="gpu-row">
+                            <div class="d-flex align-center">
+                                <span class="truncated gpu-name">{{ gpu.name || gpu.uuid }}</span>
+                                <span v-if="gpuMemory(gpu)" class="caption grey--text ml-1 text-no-wrap">{{ gpuMemory(gpu) }}</span>
+                            </div>
+                            <div v-for="metric in gpuMetricRows(gpu)" :key="metric.label" class="gpu-meter">
+                                <span class="gpu-meter-label">{{ metric.label }}</span>
+                                <v-progress-linear
+                                    :background-color="metric.backgroundColor"
+                                    height="14"
+                                    :color="metric.color"
+                                    :value="clampPercent(metricValue(metric))"
+                                >
+                                    <span style="font-size: 11px">{{ formatPercent(metricValue(metric)) }}</span>
+                                </v-progress-linear>
+                                <span v-if="hasMetric(metric.peak)" class="caption grey--text gpu-peak">pk {{ formatPercent(metric.peak) }}</span>
+                            </div>
+                        </div>
+                    </template>
+                    <span v-else>{{ gpuCountText(item.gpus) }}</span>
+                </div>
                 <span v-else>-</span>
             </template>
 
@@ -181,6 +203,61 @@ export default {
                 this.nodes = data.nodes;
             });
         },
+        hasMetric(value) {
+            return value !== null && value !== undefined;
+        },
+        metricValue(metric) {
+            return this.hasMetric(metric.avg) ? metric.avg : metric.peak;
+        },
+        clampPercent(value) {
+            if (!this.hasMetric(value)) {
+                return 0;
+            }
+            return Math.max(0, Math.min(100, value));
+        },
+        formatPercent(value) {
+            if (!this.hasMetric(value)) {
+                return '-';
+            }
+            return this.$format.percent(value) + '%';
+        },
+        gpuCountText(count) {
+            return count === 1 ? '1 GPU' : `${count} GPUs`;
+        },
+        gpuMemory(gpu) {
+            if (this.hasMetric(gpu.used_memory_bytes) && this.hasMetric(gpu.total_memory_bytes)) {
+                return `${this.$format.formatBytes(gpu.used_memory_bytes)} / ${this.$format.formatBytes(gpu.total_memory_bytes)}`;
+            }
+            if (this.hasMetric(gpu.total_memory_bytes)) {
+                return this.$format.formatBytes(gpu.total_memory_bytes);
+            }
+            return '';
+        },
+        gpuMetricRows(gpu) {
+            return [
+                {
+                    label: 'GPU',
+                    avg: gpu.usage_average_percent,
+                    peak: gpu.usage_peak_percent,
+                    color: 'green lighten-1',
+                    backgroundColor: 'green lighten-4',
+                },
+                {
+                    label: 'Mem',
+                    avg: gpu.memory_usage_average_percent,
+                    peak: gpu.memory_usage_peak_percent,
+                    color: 'purple lighten-1',
+                    backgroundColor: 'purple lighten-4',
+                },
+                {
+                    label: 'SM',
+                    avg: gpu.compute_occupancy_average_percent,
+                    peak: gpu.compute_occupancy_peak_percent,
+                    color: 'orange lighten-1',
+                    backgroundColor: 'orange lighten-4',
+                },
+            ].filter((metric) => this.hasMetric(metric.avg) || this.hasMetric(metric.peak));
+        },
     },
 };
 </script>
@@ -209,5 +286,32 @@ export default {
     text-overflow: ellipsis;
     display: inline-block;
     vertical-align: bottom;
+}
+.gpu-cell {
+    min-width: 220px;
+}
+.gpu-row + .gpu-row {
+    border-top: 1px solid rgba(0, 0, 0, 0.08);
+    margin-top: 4px;
+    padding-top: 4px;
+}
+.gpu-name {
+    max-width: 20ch;
+}
+.gpu-meter {
+    align-items: center;
+    display: grid;
+    gap: 4px;
+    grid-template-columns: 28px minmax(72px, 1fr) 44px;
+    height: 16px;
+}
+.gpu-meter-label {
+    color: rgba(0, 0, 0, 0.6);
+    font-size: 11px;
+    line-height: 1;
+}
+.gpu-peak {
+    font-size: 11px !important;
+    white-space: nowrap;
 }
 </style>

--- a/model/node.go
+++ b/model/node.go
@@ -205,6 +205,9 @@ type GPU struct {
 	UsageAverage *timeseries.TimeSeries
 	UsagePeak    *timeseries.TimeSeries
 
+	ComputeOccupancyAverage *timeseries.TimeSeries
+	ComputeOccupancyPeak    *timeseries.TimeSeries
+
 	Temperature *timeseries.TimeSeries
 	PowerWatts  *timeseries.TimeSeries
 


### PR DESCRIPTION
## Summary

This surfaces richer GPU telemetry in Coroot so GPU hosts are easier to triage from the Nodes overview and existing node/application GPU audit views.

GPU nodes are different from ordinary compute nodes: GPUs are rare, expensive, and often the reason the host exists at all. Enterprises running accelerator fleets need to know whether those devices are idle, memory-bound, poorly occupied, or saturated. CPU, memory, and network percentages are not enough on GPU hosts; utilization and compute occupancy need first-class visibility because they directly affect capacity planning, workload placement, cost control, and model/application throughput.

## What changed

- Adds node model fields and Prometheus queries for the new node-agent compute occupancy metrics:
  - `node_resources_gpu_compute_occupancy_percent_avg`
  - `node_resources_gpu_compute_occupancy_percent_peak`
- Extends the Nodes overview API response with per-GPU stats, including UUID, name, driver, total/used memory, average/peak GPU utilization, average/peak memory utilization, average/peak compute occupancy, temperature, and power.
- Updates the Nodes overview GPU column from a simple count to compact per-GPU rows with:
  - GPU name or UUID
  - vRAM used/total when available
  - GPU utilization bar with peak value
  - memory utilization bar with peak value
  - SM/compute occupancy bar with peak value when available
- Adds compute occupancy chart groups to node and application GPU audit reports when occupancy data is present.
- Updates node-agent documentation to describe Nsight Systems GPU metrics as the preferred source for node-level utilization/memory metrics when available, with NVML fallback.

## Why utilization and occupancy both matter

GPU utilization shows whether the accelerator is active, while occupancy helps explain whether the workload is keeping GPU compute resources effectively busy. That distinction is important for enterprise GPU operations: a workload can report some GPU activity while still wasting accelerator capacity through low occupancy, memory bottlenecks, or inefficient kernels. Making both signals visible at the node level gives operators a faster path from "this host has GPUs" to "these expensive GPUs are being used well, badly, or not at all."

## Companion exporter work

Depends on coroot/coroot-node-agent#307, which adds Nsight Systems collection and exports the compute occupancy metrics consumed here. The UI remains compatible with older agents because the new fields are omitted when the metrics are absent.

## Testing

- `npm run lint`
- `npm run build-prod` (passes with existing Browserslist/webpack size/deprecation warnings)
- `docker run --rm -v "$PWD":/src -w /src golang:1.25-bookworm sh -c 'apt-get update >/tmp/apt-update.log && apt-get install -y liblz4-dev >/tmp/apt-install.log && /usr/local/go/bin/go test ./...'`
