### PR TITLE
fix: match only full ReplicaSet hash suffixes

### DIFF
--- a/model/application_id.go
+++ b/model/application_id.go
@@ -14,7 +14,7 @@ const (
 
 var (
 	ApplicationIdZero = ApplicationId{}
-	hexPattern        = regexp.MustCompile(`[\da-f]+`)
+	hexPattern        = regexp.MustCompile(`^[\da-f]+$`)
 )
 
 type ApplicationId struct {

--- a/model/application_id_test.go
+++ b/model/application_id_test.go
@@ -19,3 +19,11 @@ func TestApplicationId(t *testing.T) {
 	id, _ = NewApplicationIdFromString("external:ExternalService:external:30001", "fallback")
 	assert.Equal(t, ApplicationId{ClusterId: "external", Kind: ApplicationKindExternalService, Name: "external:30001", Namespace: "external"}, id)
 }
+
+func TestNewApplicationIdReplicaSet(t *testing.T) {
+	id := NewApplicationId("cluster", "default", ApplicationKindReplicaSet, "catalog-6799fc88d8")
+	assert.Equal(t, ApplicationId{ClusterId: "cluster", Kind: ApplicationKindDeployment, Name: "catalog", Namespace: "default"}, id)
+
+	id = NewApplicationId("cluster", "default", ApplicationKindReplicaSet, "catalog-blue")
+	assert.Equal(t, ApplicationId{ClusterId: "cluster", Kind: ApplicationKindReplicaSet, Name: "catalog-blue", Namespace: "default"}, id)
+}


### PR DESCRIPTION
## What
Tiny footgun fix: standalone ReplicaSets like `catalog-blue` were parsed as a Deployment named `catalog`, because the hash check matched any hex-looking substring in the last suffix.

Now the suffix must be fully hex before Coroot folds a ReplicaSet into its Deployment. Generated names like `catalog-6799fc88d8` still work.

## Repro
Add this case:

```go
id := NewApplicationId("cluster", "default", ApplicationKindReplicaSet, "catalog-blue")
assert.Equal(t, ApplicationKindReplicaSet, id.Kind)
assert.Equal(t, "catalog-blue", id.Name)
```

Before this patch it returns `Deployment/catalog`. after this patch it stays `ReplicaSet/catalog-blue`.

This is real-world triggerable: Kubernetes allows ReplicaSets as top-level resources, and `catalog-blue` is a valid DNS-style ReplicaSet name. no weird quota edge case here.

## Tests
- `go test ./model -count=1`
- `go vet ./model`
- `git diff --check HEAD~1..HEAD`

`go test ./...` is blocked in my local env by missing `static` embed files and `liblz4` pkg-config deps, not by this change.

No related issue/PR found, afaict.