### PR TITLE
fix: avoid over-normalizing Kubernetes application ids

### DIFF
--- a/model/application_id.go
+++ b/model/application_id.go
@@ -14,7 +14,7 @@ const (
 
 var (
 	ApplicationIdZero = ApplicationId{}
-	hexPattern        = regexp.MustCompile(`^[\da-f]+$`)
+	replicaSetHash    = regexp.MustCompile(`^[\da-f]{10}$`)
 )
 
 type ApplicationId struct {
@@ -28,15 +28,18 @@ func NewApplicationId(clusterId, ns string, kind ApplicationKind, name string) A
 	switch kind {
 	case ApplicationKindReplicaSet:
 		parts := strings.Split(name, "-")
-		if hexPattern.MatchString(parts[len(parts)-1]) {
+		if len(parts) > 1 && replicaSetHash.MatchString(parts[len(parts)-1]) {
 			kind = ApplicationKindDeployment
 			name = strings.Join(parts[:len(parts)-1], "-")
 		}
 	case ApplicationKindJob:
 		parts := strings.Split(name, "-")
-		if _, err := strconv.ParseUint(parts[len(parts)-1], 10, 64); err == nil {
-			kind = ApplicationKindCronJob
-			name = strings.Join(parts[:len(parts)-1], "-")
+		suffix := parts[len(parts)-1]
+		if len(parts) > 1 && len(suffix) >= 10 {
+			if _, err := strconv.ParseUint(suffix, 10, 64); err == nil {
+				kind = ApplicationKindCronJob
+				name = strings.Join(parts[:len(parts)-1], "-")
+			}
 		}
 	case "", "<none>":
 		kind = ApplicationKindPod

--- a/model/application_id_test.go
+++ b/model/application_id_test.go
@@ -26,4 +26,21 @@ func TestNewApplicationIdReplicaSet(t *testing.T) {
 
 	id = NewApplicationId("cluster", "default", ApplicationKindReplicaSet, "catalog-blue")
 	assert.Equal(t, ApplicationId{ClusterId: "cluster", Kind: ApplicationKindReplicaSet, Name: "catalog-blue", Namespace: "default"}, id)
+
+	id = NewApplicationId("cluster", "default", ApplicationKindReplicaSet, "catalog-a")
+	assert.Equal(t, ApplicationId{ClusterId: "cluster", Kind: ApplicationKindReplicaSet, Name: "catalog-a", Namespace: "default"}, id)
+
+	id = NewApplicationId("cluster", "default", ApplicationKindReplicaSet, "abcdef1234")
+	assert.Equal(t, ApplicationId{ClusterId: "cluster", Kind: ApplicationKindReplicaSet, Name: "abcdef1234", Namespace: "default"}, id)
+}
+
+func TestNewApplicationIdJob(t *testing.T) {
+	id := NewApplicationId("cluster", "default", ApplicationKindJob, "backup-1716480000")
+	assert.Equal(t, ApplicationId{ClusterId: "cluster", Kind: ApplicationKindCronJob, Name: "backup", Namespace: "default"}, id)
+
+	id = NewApplicationId("cluster", "default", ApplicationKindJob, "db-migration-1")
+	assert.Equal(t, ApplicationId{ClusterId: "cluster", Kind: ApplicationKindJob, Name: "db-migration-1", Namespace: "default"}, id)
+
+	id = NewApplicationId("cluster", "default", ApplicationKindJob, "1716480000")
+	assert.Equal(t, ApplicationId{ClusterId: "cluster", Kind: ApplicationKindJob, Name: "1716480000", Namespace: "default"}, id)
 }


### PR DESCRIPTION
Fixes a small k8s app-id papercut. Some user-created Jobs and ReplicaSets can look generated, so Coroot could fold them into the wrong parent app. Not great.

Repro before this patch:
- `NewApplicationId(..., ReplicaSet, "catalog-a")` becomes Deployment `catalog`
- `NewApplicationId(..., Job, "db-migration-1")` becomes CronJob `db-migration`

Both names are valid k8s object names, so this can happen in real clusters. The fix only normalizes the generated-looking forms: ReplicaSet `name-<10 hex chars>` and Job `name-<10+ digits>`.

Tested: `go test ./model`