### PR TITLE
feat: add tab visibility refresh and auto-refresh interval picker

### DIFF
--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -283,10 +283,12 @@ export default {
         this.$events.watch(this, this.getUser, 'projects');
         this.getUser();
         window.addEventListener('keydown', this.searchListener);
+        document.addEventListener('visibilitychange', this.handleVisibilityChange);
     },
 
     beforeDestroy() {
         window.removeEventListener('keydown', this.searchListener);
+        document.removeEventListener('visibilitychange', this.handleVisibilityChange);
     },
 
     computed: {
@@ -427,6 +429,11 @@ export default {
         },
         refresh() {
             this.$events.emit('refresh');
+        },
+        handleVisibilityChange() {
+            if (document.visibilityState === 'visible') {
+                this.$events.emit('refresh');
+            }
         },
         toggleMenu() {
             this.menuCollapsed = !this.menuCollapsed;

--- a/front/src/components/RefreshPicker.vue
+++ b/front/src/components/RefreshPicker.vue
@@ -1,0 +1,94 @@
+<template>
+    <v-menu v-model="menu" :close-on-content-click="false" left offset-y attach=".v-app-bar">
+        <template #activator="{ on, attrs }">
+            <v-btn v-on="on" plain outlined height="40" class="px-2 ml-2">
+                <v-icon>mdi-refresh</v-icon>
+                <span v-if="!small" class="ml-1">{{ selectedRefresh === 0 ? 'Refresh' : currentLabel }}</span>
+                <v-icon v-if="!small" small class="ml-1">mdi-chevron-{{ attrs['aria-expanded'] === 'true' ? 'up' : 'down' }}</v-icon>
+            </v-btn>
+        </template>
+        <v-list dense class="list">
+            <v-list-item @click="manualRefresh">
+                <v-list-item-icon class="mr-2"><v-icon small>mdi-refresh</v-icon></v-list-item-icon>
+                <v-list-item-content>Refresh now</v-list-item-content>
+            </v-list-item>
+            <v-divider />
+            <v-list-item
+                v-for="r in refreshOptions"
+                :key="r.value"
+                @click="setRefresh(r.value)"
+                :input-value="selectedRefresh === r.value"
+            >
+                <v-list-item-content>{{ r.text }}</v-list-item-content>
+            </v-list-item>
+        </v-list>
+    </v-menu>
+</template>
+
+<script>
+export default {
+    props: {
+        small: Boolean,
+    },
+    data() {
+        return {
+            menu: false,
+            refreshInterval: null,
+            selectedRefresh: 0,
+            refreshOptions: [
+                { text: 'Off', value: 0 },
+                { text: '30s', value: 30 },
+                { text: '1m', value: 60 },
+                { text: '5m', value: 300 },
+                { text: '10m', value: 600 },
+            ],
+        };
+    },
+    computed: {
+        currentLabel() {
+            const opt = this.refreshOptions.find((r) => r.value === this.selectedRefresh);
+            return opt ? opt.text : 'Off';
+        },
+    },
+    mounted() {
+        const saved = this.$storage.local('auto-refresh');
+        this.selectedRefresh = saved || 0;
+        this.startRefresh();
+    },
+    beforeDestroy() {
+        this.stopRefresh();
+    },
+    methods: {
+        manualRefresh() {
+            this.$events.emit('refresh');
+            this.menu = false;
+        },
+        startRefresh() {
+            this.stopRefresh();
+            if (this.selectedRefresh > 0) {
+                this.refreshInterval = setInterval(() => {
+                    this.$events.emit('refresh');
+                }, this.selectedRefresh * 1000);
+            }
+        },
+        stopRefresh() {
+            if (this.refreshInterval) {
+                clearInterval(this.refreshInterval);
+                this.refreshInterval = null;
+            }
+        },
+        setRefresh(val) {
+            this.selectedRefresh = val;
+            this.$storage.local('auto-refresh', val);
+            this.startRefresh();
+            this.menu = false;
+        },
+    },
+};
+</script>
+
+<style scoped>
+.list:deep(.v-list-item) {
+    min-height: 36px;
+}
+</style>

--- a/front/src/components/TimePicker.vue
+++ b/front/src/components/TimePicker.vue
@@ -74,6 +74,7 @@ export default {
         };
     },
 
+
     watch: {
         menu(v) {
             if (!v) {
@@ -115,6 +116,7 @@ export default {
             this.to = this.dates[1] + ' 23:59';
             this.picker = false;
         },
+
     },
 
     computed: {

--- a/front/src/views/Views.vue
+++ b/front/src/views/Views.vue
@@ -16,8 +16,9 @@
                 </div>
                 <v-spacer />
 
-                <div class="ml-3">
+                <div class="ml-3 d-flex align-center gap-2">
                     <TimePicker :small="$vuetify.breakpoint.xsOnly" />
+                    <RefreshPicker :small="$vuetify.breakpoint.xsOnly" />
                 </div>
             </v-container>
         </v-app-bar>
@@ -34,6 +35,7 @@
 
 <script>
 import TimePicker from '@/components/TimePicker.vue';
+import RefreshPicker from '@/components/RefreshPicker.vue';
 
 export const views = {
     applications: { name: 'Applications', icon: 'mdi-apps' },
@@ -61,7 +63,7 @@ export default {
         noTitle: Boolean,
     },
 
-    components: { TimePicker },
+    components: { TimePicker, RefreshPicker },
 
     computed: {
         view() {


### PR DESCRIPTION
Problem
When switching browser tabs, Coroot data becomes stale 
and does not refresh automatically. There was also no 
way to set a periodic auto-refresh interval.

Solution
1. Added Page Visibility API listener in App.vue data 
   refreshes instantly when user returns to the Coroot tab.

2. Added a new RefreshPicker component  a separate button 
   next to TimePicker with:
   - "Refresh now" for manual refresh
   - Auto-refresh intervals: Off / 30s / 1m / 5m / 10m
   - Persists selection in localStorage

Changes
- front/src/App.vue  visibilitychange listener
- front/src/components/RefreshPicker.vue  new component
- front/src/views/Views.vue  RefreshPicker integrated
- front/src/components/TimePicker.vue cleanup only

<img width="1881" height="985" alt="image" src="https://github.com/user-attachments/assets/8b73480a-d145-43fa-933c-16f813b92814" />
<img width="1886" height="976" alt="image" src="https://github.com/user-attachments/assets/dba2f909-d8b3-4a30-8c4a-da5930b6a0b9" />
