### PR TITLE
Track total redis keys count and TTL in redis section

### DIFF
--- a/auditor/redis.go
+++ b/auditor/redis.go
@@ -30,7 +30,7 @@ func (a *appAuditor) redis() {
 	table := report.GetOrCreateTable("Instance", "Role", "Status", "Version")
 	latencyChart := report.GetOrCreateChart("Redis average latency, seconds", nil)
 	queriesChart := report.GetOrCreateChartGroup("Redis queries on <selector>, per seconds", nil)
-	keyspaceChart := report.GetOrCreateChartGroup("Redis keyspace on <selector>, keys", nil)
+	keysChart := report.GetOrCreateChartGroup("Redis keys <selector>", nil)
 
 	availabilityCheck.AddWidget(table.Widget())
 	latencyCheck.AddWidget(latencyChart.Widget())
@@ -100,16 +100,30 @@ func (a *appAuditor) redis() {
 				AddMany(byCmd, 5, timeseries.NanSum)
 		}
 
-		if keyspaceChart != nil && (len(i.Redis.Keys) > 0 || len(i.Redis.KeysExpiring) > 0) {
+		if keysChart != nil && (len(i.Redis.Keys) > 0 || len(i.Redis.KeysExpiring) > 0) {
+			totalKeys := timeseries.NewAggregate(timeseries.NanSum)
+			for _, ts := range i.Redis.Keys {
+				totalKeys.Add(ts)
+			}
+			keysChart.GetOrCreateChart("overview").Feature().AddSeries(i.Name, totalKeys.Get())
+
 			byDb := map[string]model.SeriesData{}
 			for db, ts := range i.Redis.Keys {
-				byDb[db+" keys"] = ts
+				val := ts.Reduce(timeseries.NanSum)
+				if !timeseries.IsNaN(val) && val > 0 {
+					byDb[db+" keys"] = ts
+				}
 			}
 			for db, ts := range i.Redis.KeysExpiring {
-				byDb[db+" expiring keys"] = ts
+				val := ts.Reduce(timeseries.NanSum)
+				if !timeseries.IsNaN(val) && val > 0 {
+					byDb[db+" expiring keys"] = ts
+				}
 			}
-			keyspaceChart.GetOrCreateChart(i.Name).Sorted().
-				AddMany(byDb, 20, timeseries.Max)
+			if len(byDb) > 0 {
+				keysChart.GetOrCreateChart(i.Name).Sorted().
+					AddMany(byDb, 20, timeseries.Max)
+			}
 		}
 	}
 }

--- a/auditor/redis.go
+++ b/auditor/redis.go
@@ -30,6 +30,7 @@ func (a *appAuditor) redis() {
 	table := report.GetOrCreateTable("Instance", "Role", "Status", "Version")
 	latencyChart := report.GetOrCreateChart("Redis average latency, seconds", nil)
 	queriesChart := report.GetOrCreateChartGroup("Redis queries on <selector>, per seconds", nil)
+	keyspaceChart := report.GetOrCreateChartGroup("Redis keyspace on <selector>, keys", nil)
 
 	availabilityCheck.AddWidget(table.Widget())
 	latencyCheck.AddWidget(latencyChart.Widget())
@@ -97,6 +98,18 @@ func (a *appAuditor) redis() {
 			}
 			queriesChart.GetOrCreateChart(i.Name).Stacked().Sorted().
 				AddMany(byCmd, 5, timeseries.NanSum)
+		}
+
+		if keyspaceChart != nil && (len(i.Redis.Keys) > 0 || len(i.Redis.KeysExpiring) > 0) {
+			byDb := map[string]model.SeriesData{}
+			for db, ts := range i.Redis.Keys {
+				byDb[db+" keys"] = ts
+			}
+			for db, ts := range i.Redis.KeysExpiring {
+				byDb[db+" expiring keys"] = ts
+			}
+			keyspaceChart.GetOrCreateChart(i.Name).Sorted().
+				AddMany(byDb, 20, timeseries.Max)
 		}
 	}
 }

--- a/constructor/queries.go
+++ b/constructor/queries.go
@@ -392,6 +392,8 @@ var QUERIES = []Query{
 	qDB("redis_instance_info", `redis_instance_info`, "redis_version", "role"),
 	qDB("redis_commands_duration_seconds_total", `rate(redis_commands_duration_seconds_total[$RANGE])`, "cmd"),
 	qDB("redis_commands_total", `rate(redis_commands_total[$RANGE])`, "cmd"),
+	qDB("redis_db_keys", `redis_db_keys`, "db"),
+	qDB("redis_db_keys_expiring", `redis_db_keys_expiring`, "db"),
 
 	qDB("mongo_up", `mongo_up`),
 	qDB("mongo_scrape_error", `mongo_scrape_error`, "error", "warning"),

--- a/constructor/redis.go
+++ b/constructor/redis.go
@@ -35,5 +35,9 @@ func redis(instance *model.Instance, queryName string, m *model.MetricValues) {
 		instance.Redis.CallsTime[m.Labels["cmd"]] = merge(instance.Redis.CallsTime[m.Labels["cmd"]], m.Values, timeseries.Any)
 	case "redis_commands_total":
 		instance.Redis.Calls[m.Labels["cmd"]] = merge(instance.Redis.Calls[m.Labels["cmd"]], m.Values, timeseries.Any)
+	case "redis_db_keys":
+		instance.Redis.Keys[m.Labels["db"]] = merge(instance.Redis.Keys[m.Labels["db"]], m.Values, timeseries.Any)
+	case "redis_db_keys_expiring":
+		instance.Redis.KeysExpiring[m.Labels["db"]] = merge(instance.Redis.KeysExpiring[m.Labels["db"]], m.Values, timeseries.Any)
 	}
 }

--- a/model/redis.go
+++ b/model/redis.go
@@ -10,10 +10,12 @@ type Redis struct {
 	Up    *timeseries.TimeSeries
 	Error LabelLastValue
 
-	Version   LabelLastValue
-	Role      LabelLastValue
-	Calls     map[string]*timeseries.TimeSeries
-	CallsTime map[string]*timeseries.TimeSeries
+	Version      LabelLastValue
+	Role         LabelLastValue
+	Calls        map[string]*timeseries.TimeSeries
+	CallsTime    map[string]*timeseries.TimeSeries
+	Keys         map[string]*timeseries.TimeSeries
+	KeysExpiring map[string]*timeseries.TimeSeries
 }
 
 func NewRedis(internalExporter bool) *Redis {
@@ -21,6 +23,8 @@ func NewRedis(internalExporter bool) *Redis {
 		InternalExporter: internalExporter,
 		Calls:            map[string]*timeseries.TimeSeries{},
 		CallsTime:        map[string]*timeseries.TimeSeries{},
+		Keys:             map[string]*timeseries.TimeSeries{},
+		KeysExpiring:     map[string]*timeseries.TimeSeries{},
 	}
 }
 


### PR DESCRIPTION
Hi,

This is a small addition to track redis keyspace. As coroot cluster agent already scrapes **redis_db_keys** and **redis_db_keys_expiring** metrics, just added a new chart in redis section using those.

It will be helpful to track key size, their TTLs of each redis instance