### PR TITLE
fix: respect auth-anonymous-role in MCP bearer auth

### DIFF
--- a/api/mcp_oauth.go
+++ b/api/mcp_oauth.go
@@ -113,6 +113,9 @@ func (api *Api) mcpIssueToken(audience string, userId int, clientId string, ttl 
 func (api *Api) MCPUserFromBearer(r *http.Request) *db.User {
 	auth := r.Header.Get("Authorization")
 	if !strings.HasPrefix(auth, mcpBearerPrefix) {
+		if api.authAnonymousRole != "" {
+			return db.AnonymousUser(api.authAnonymousRole)
+		}
 		return nil
 	}
 	token := strings.TrimPrefix(auth, mcpBearerPrefix)
@@ -126,6 +129,9 @@ func (api *Api) MCPUserFromBearer(r *http.Request) *db.User {
 	}
 	user, err := api.db.GetUser(userId)
 	if err != nil || user == nil {
+		if api.authAnonymousRole != "" {
+			return db.AnonymousUser(api.authAnonymousRole)
+		}
 		return nil
 	}
 	return user


### PR DESCRIPTION
## Problem

When `--auth-anonymous-role` is set, the web UI works without login because `GetUser()` returns an anonymous user. However, `MCPUserFromBearer()` does not check this flag, so the MCP endpoint always returns 401 in anonymous mode.

The OAuth flow technically completes (the consent page shows "Anonymous", issues a code with `Subject: "0"`), but the resulting access token references `userId=0` which has no DB row. `MCPUserFromBearer()` calls `db.GetUser(0)`, gets `ErrNotFound`, and returns `nil` → 401.

This affects users running Coroot behind auth proxies (Authelia, Authentik, oauth2-proxy) who use `--auth-anonymous-role=Admin` because the proxy handles authentication and Coroot doesn't need its own.

## Fix

Fall back to `db.AnonymousUser(api.authAnonymousRole)` in `MCPUserFromBearer()` when:
1. No bearer token is present and anonymous role is configured
2. The bearer token references a non-existent user (e.g., `userId=0`) and anonymous role is configured

This mirrors the behavior of `GetUser()` — when anonymous mode is active, every request is treated as authenticated with the configured role.

## Testing

Tested with Coroot v1.22.0 + `--auth-anonymous-role=Admin` behind Caddy + Authelia. MCP client (Claude Code) can now connect without completing the OAuth flow — the `/mcp` endpoint returns tool responses instead of 401.

With anonymous mode disabled, behavior is unchanged: `MCPUserFromBearer()` still requires a valid bearer token from the full OAuth flow.