### PR TITLE
fix: add retention/cleanup for resolved alerts and alert notifications

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -48,6 +48,8 @@ type Config struct {
 
 	ClickHouseSpaceManager ClickHouseSpaceManager `yaml:"clickhouse_space_manager"`
 
+	Alerts Alerts `yaml:"alerts"`
+
 	CorootCloud *cloud.Settings `yaml:"corootCloud"`
 
 	BootstrapClickhouse *Clickhouse `yaml:"-"`
@@ -105,6 +107,10 @@ type Profiles struct {
 
 type Metrics struct {
 	TTL timeseries.Duration `yaml:"ttl"`
+}
+
+type Alerts struct {
+	RetentionPeriod timeseries.Duration `yaml:"retention_period"`
 }
 
 type Postgres struct {
@@ -215,6 +221,9 @@ func NewConfig() *Config {
 		Metrics: Metrics{
 			TTL: 7 * timeseries.Day,
 		},
+		Alerts: Alerts{
+			RetentionPeriod: 90 * timeseries.Day,
+		},
 
 		Auth: Auth{
 			BootstrapAdminPassword: db.AdminUserDefaultPassword,
@@ -324,6 +333,9 @@ func (cfg *Config) Validate() error {
 	}
 	if cfg.ClickHouseSpaceManager.UsageThresholdPercent < 0 || cfg.ClickHouseSpaceManager.UsageThresholdPercent > 100 {
 		return fmt.Errorf("invalid usage_threshold_percent: %d", cfg.ClickHouseSpaceManager.UsageThresholdPercent)
+	}
+	if cfg.Alerts.RetentionPeriod <= 0 {
+		return fmt.Errorf("invalid alerts.retention_period: %d", cfg.Alerts.RetentionPeriod)
 	}
 
 	return nil

--- a/config/flags.go
+++ b/config/flags.go
@@ -23,6 +23,7 @@ var (
 	logsTTL                                     = timeseries.DurationFlag(kingpin.Flag("logs-ttl", "Logs TTL (e.g. 8h, 3d, 2w; default 7d)").Envar("LOGS_TTL"))
 	profilesTTL                                 = timeseries.DurationFlag(kingpin.Flag("profiles-ttl", "Profiles TTL (e.g. 8h, 3d, 2w; default 7d)").Envar("PROFILES_TTL"))
 	metricsTTL                                  = timeseries.DurationFlag(kingpin.Flag("metrics-ttl", "Metrics TTL (e.g. 8h, 30d, 1y; default 7d)").Envar("METRICS_TTL"))
+	alertsRetentionPeriod                       = timeseries.DurationFlag(kingpin.Flag("alerts-retention-period", "How long to keep resolved alerts and sent notifications (e.g. 30d, 90d; default 90d)").Envar("ALERTS_RETENTION_PERIOD"))
 	pgConnectionString                          = kingpin.Flag("pg-connection-string", "Postgres connection string (sqlite is used if not set)").Envar("PG_CONNECTION_STRING").String()
 	doNotCheckForDeployments                    = kingpin.Flag("do-not-check-for-deployments", "Don't check for new deployments").Envar("DO_NOT_CHECK_FOR_DEPLOYMENTS").Bool()
 	doNotCheckForUpdates                        = kingpin.Flag("do-not-check-for-updates", "Don't check for new versions").Envar("DO_NOT_CHECK_FOR_UPDATES").Bool()
@@ -107,6 +108,9 @@ func (cfg *Config) ApplyFlags() {
 	}
 	if *metricsTTL > 0 {
 		cfg.Metrics.TTL = *metricsTTL
+	}
+	if *alertsRetentionPeriod > 0 {
+		cfg.Alerts.RetentionPeriod = *alertsRetentionPeriod
 	}
 	if *pgConnectionString != "" {
 		cfg.Postgres = &Postgres{ConnectionString: *pgConnectionString}

--- a/db/alert.go
+++ b/db/alert.go
@@ -631,6 +631,16 @@ func (db *DB) GetLatestAlertsByRule(projectId ProjectId, ruleId string) ([]*mode
 	return alerts, nil
 }
 
+func (db *DB) DeleteOldAlerts(before timeseries.Time) (int64, error) {
+	result, err := db.db.Exec(
+		"DELETE FROM alert WHERE resolved_at > 0 AND resolved_at < $1",
+		before)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 func (db *DB) HasAlerts(projectId ProjectId) (bool, error) {
 	var exists int
 	err := db.db.QueryRow(

--- a/db/alert_notification.go
+++ b/db/alert_notification.go
@@ -33,7 +33,7 @@ type AlertNotificationDetails struct {
 }
 
 func (n *AlertNotification) Migrate(m *Migrator) error {
-	return m.Exec(`
+	err := m.Exec(`
 	CREATE TABLE IF NOT EXISTS alert_notification (
 		project_id TEXT NOT NULL REFERENCES project(id),
 		alert_id TEXT NOT NULL,
@@ -47,6 +47,13 @@ func (n *AlertNotification) Migrate(m *Migrator) error {
 		details TEXT
 	);
 `)
+	if err != nil {
+		return err
+	}
+	if err = m.Exec(`CREATE INDEX IF NOT EXISTS alert_notification_project_alert ON alert_notification (project_id, alert_id)`); err != nil {
+		return err
+	}
+	return m.Exec(`CREATE INDEX IF NOT EXISTS alert_notification_timestamp ON alert_notification (timestamp)`)
 }
 
 func (db *DB) PutAlertNotification(n AlertNotification) {
@@ -147,6 +154,16 @@ func (db *DB) GetAlertNotificationsByAlertIds(projectId ProjectId, alertIds []st
 		res[n.AlertId] = append(res[n.AlertId], n)
 	}
 	return res, nil
+}
+
+func (db *DB) DeleteOldAlertNotifications(before timeseries.Time) (int64, error) {
+	result, err := db.db.Exec(
+		"DELETE FROM alert_notification WHERE timestamp < $1",
+		before)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 func (db *DB) GetPreviousAlertNotifications(n AlertNotification) ([]AlertNotification, error) {

--- a/main.go
+++ b/main.go
@@ -143,7 +143,7 @@ func main() {
 
 	incidents := watchers.NewIncidents(database, a.IncidentRCA)
 
-	watchers.Start(database, promCache, pricing, incidents, !cfg.DoNotCheckForDeployments, globalClickhouse, globalPrometheus, cfg.ClickHouseSpaceManager, nil, nil)
+	watchers.Start(database, promCache, pricing, incidents, !cfg.DoNotCheckForDeployments, globalClickhouse, globalPrometheus, cfg.ClickHouseSpaceManager, cfg.Alerts, nil, nil)
 
 	router := mux.NewRouter()
 	router.Use(statsCollector.MiddleWare)

--- a/watchers/watchers.go
+++ b/watchers/watchers.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/klog"
 )
 
-func Start(database *db.DB, mcache *cache.Cache, pricing *pricing.Manager, incidents *Incidents, checkDeployments bool, globalClickHouse *db.IntegrationClickhouse, globalPrometheus *db.IntegrationPrometheus, spaceManagerCfg config.ClickHouseSpaceManager, logPatternEvaluator LogPatternEvaluator, kubernetesEventEvaluator KubernetesEventEvaluator) {
+func Start(database *db.DB, mcache *cache.Cache, pricing *pricing.Manager, incidents *Incidents, checkDeployments bool, globalClickHouse *db.IntegrationClickhouse, globalPrometheus *db.IntegrationPrometheus, spaceManagerCfg config.ClickHouseSpaceManager, alertsCfg config.Alerts, logPatternEvaluator LogPatternEvaluator, kubernetesEventEvaluator KubernetesEventEvaluator) {
 	var deployments *Deployments
 	if checkDeployments {
 		deployments = NewDeployments(database, pricing)
@@ -34,6 +34,7 @@ func Start(database *db.DB, mcache *cache.Cache, pricing *pricing.Manager, incid
 	pending := map[db.ProjectId]bool{}
 	pendingLock := sync.Mutex{}
 	lastSpaceManagerRun := time.Time{}
+	lastAlertsCleanupRun := time.Time{}
 
 	// Fast consumer goroutine - just receives and deduplicates
 	go func() {
@@ -89,6 +90,10 @@ func Start(database *db.DB, mcache *cache.Cache, pricing *pricing.Manager, incid
 				if time.Since(lastSpaceManagerRun) >= time.Hour {
 					lastSpaceManagerRun = time.Now()
 					runSpaceManagerOnce(spaceManagerCfg, database, globalClickHouse)
+				}
+				if time.Since(lastAlertsCleanupRun) >= time.Hour {
+					lastAlertsCleanupRun = time.Now()
+					runAlertsCleanupOnce(alertsCfg, database)
 				}
 			}
 		}
@@ -200,6 +205,25 @@ func handleProjectUpdate(database *db.DB, cache *cache.Cache, pricing *pricing.M
 	}
 	wg.Wait()
 	klog.Infof("%s: iteration done in %s", project.Id, time.Since(start).Truncate(time.Millisecond))
+}
+
+func runAlertsCleanupOnce(cfg config.Alerts, database *db.DB) {
+	if cfg.RetentionPeriod <= 0 {
+		return
+	}
+	before := timeseries.Now().Add(-cfg.RetentionPeriod)
+	deletedAlerts, err := database.DeleteOldAlerts(before)
+	if err != nil {
+		klog.Errorf("alerts cleanup: failed to delete old alerts: %v", err)
+	} else if deletedAlerts > 0 {
+		klog.Infof("alerts cleanup: deleted %d resolved alerts older than %s", deletedAlerts, cfg.RetentionPeriod)
+	}
+	deletedNotifications, err := database.DeleteOldAlertNotifications(before)
+	if err != nil {
+		klog.Errorf("alerts cleanup: failed to delete old alert notifications: %v", err)
+	} else if deletedNotifications > 0 {
+		klog.Infof("alerts cleanup: deleted %d alert notifications older than %s", deletedNotifications, cfg.RetentionPeriod)
+	}
 }
 
 func runSpaceManagerOnce(cfg config.ClickHouseSpaceManager, database *db.DB, globalClickHouse *db.IntegrationClickhouse) {


### PR DESCRIPTION
## Summary

The `alert` and `alert_notification` tables grow unbounded — resolved alerts and
sent notifications are never deleted, only ever inserted/updated. On long-running
instances this leads to multi-hundred-MB tables with hundreds of thousands of rows,
almost entirely historical data that's never queried.

Closes #952

## Changes

- Add a configurable `Alerts.RetentionPeriod` setting (default 90d), via
  `alerts.retention_period` in the config file, `--alerts-retention-period` flag,
  or `ALERTS_RETENTION_PERIOD` env var.
- Add `db.DeleteOldAlerts` / `db.DeleteOldAlertNotifications`, which delete
  resolved alerts (`resolved_at > 0`) and notifications older than the retention
  cutoff. Firing/unresolved alerts are never touched.
- Wire a periodic cleanup job into the existing watcher loop (`watchers.Start`),
  following the same primary-lock-gated, hourly pattern already used for the
  ClickHouse space manager.
- Add missing indexes on `alert_notification` (`project_id, alert_id` and
  `timestamp`) to support the periodic cleanup and existing lookup queries.
