### PR TITLE
Feat: Add clickhouse TLS CA file support for cert verification

### DIFF
--- a/ch/client.go
+++ b/ch/client.go
@@ -57,9 +57,7 @@ func NewLowLevelClient(ctx context.Context, cfg *db.IntegrationClickhouse) (*Low
 		HandshakeTimeout: dialTimeout,
 	}
 	if cfg.TlsEnable {
-		opts.TLS = &tls.Config{
-			InsecureSkipVerify: cfg.TlsSkipVerify,
-		}
+		opts.TLS = TlsConfig(cfg.TlsCAFile, cfg.TlsSkipVerify)
 	}
 	if dialer != nil {
 		opts.Dialer = dialer

--- a/ch/tls.go
+++ b/ch/tls.go
@@ -1,0 +1,30 @@
+package ch
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"os"
+
+	"k8s.io/klog"
+)
+
+func TlsConfig(caFile string, insecureSkipVerify bool) *tls.Config {
+	cfg := &tls.Config{InsecureSkipVerify: insecureSkipVerify}
+	if caFile != "" {
+		ca, err := os.ReadFile(caFile)
+		if err != nil {
+			klog.Fatalln(err)
+			return cfg
+		}
+		pool, err := x509.SystemCertPool()
+		if err != nil {
+			klog.Warningln("failed to load system cert pool, starting with empty pool:", err)
+			pool = x509.NewCertPool()
+		}
+		if !pool.AppendCertsFromPEM(ca) {
+			klog.Fatalf("failed to parse CA from %s", caFile)
+		}
+		cfg.RootCAs = pool
+	}
+	return cfg
+}

--- a/clickhouse/clickhouse.go
+++ b/clickhouse/clickhouse.go
@@ -2,7 +2,6 @@ package clickhouse
 
 import (
 	"context"
-	"crypto/tls"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -71,9 +70,7 @@ func NewClient(config *db.IntegrationClickhouse, project *db.Project) (*Client, 
 		opts.DialContext = dialer.Dial
 	}
 	if config.TlsEnable {
-		opts.TLS = &tls.Config{
-			InsecureSkipVerify: config.TlsSkipVerify,
-		}
+		opts.TLS = ch.TlsConfig(config.TlsCAFile, config.TlsSkipVerify)
 	}
 	conn, err := clickhouse.Open(opts)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -118,6 +118,7 @@ type Clickhouse struct {
 	Database      string `yaml:"database"`
 	TlsEnable     bool   `yaml:"tls_enable"`
 	TlsSkipVerify bool   `yaml:"tls_skip_verify"`
+	TlsCAFile     string `yaml:"tls_ca_file"`
 }
 
 func (c *Clickhouse) Validate() error {
@@ -346,6 +347,7 @@ func (cfg *Config) GetGlobalClickhouse() *db.IntegrationClickhouse {
 		InitialDatabase: clickhouse.Database,
 		TlsEnable:       clickhouse.TlsEnable,
 		TlsSkipVerify:   clickhouse.TlsSkipVerify,
+		TlsCAFile:       clickhouse.TlsCAFile,
 	}
 	if c.Auth.User == "" {
 		c.Auth.User = "default"
@@ -371,6 +373,7 @@ func (cfg *Config) GetBootstrapClickhouse() *db.IntegrationClickhouse {
 		Database:      clickhouse.Database,
 		TlsEnable:     clickhouse.TlsEnable,
 		TlsSkipVerify: clickhouse.TlsSkipVerify,
+		TlsCAFile:     clickhouse.TlsCAFile,
 	}
 	if c.Auth.User == "" {
 		c.Auth.User = "default"

--- a/config/flags.go
+++ b/config/flags.go
@@ -41,6 +41,7 @@ var (
 	globalClickhouseInitialDatabase = kingpin.Flag("global-clickhouse-initial-database", "").Envar("GLOBAL_CLICKHOUSE_INITIAL_DATABASE").String()
 	globalClickhouseTlsEnabled      = kingpin.Flag("global-clickhouse-tls-enabled", "").Envar("GLOBAL_CLICKHOUSE_TLS_ENABLED").Bool()
 	globalClickhouseTlsSkipVerify   = kingpin.Flag("global-clickhouse-tls-skip-verify", "").Envar("GLOBAL_CLICKHOUSE_TLS_SKIP_VERIFY").Bool()
+	globalClickhouseTlsCAFile       = kingpin.Flag("global-clickhouse-tls-ca-file", "Path to the CA certificate file for ClickHouse TLS verification").Envar("GLOBAL_CLICKHOUSE_TLS_CA_FILE").String()
 
 	globalPrometheusUrl            = kingpin.Flag("global-prometheus-url", "").Envar("GLOBAL_PROMETHEUS_URL").String()
 	globalPrometheusTlsSkipVerify  = kingpin.Flag("global-prometheus-tls-skip-verify", "").Envar("GLOBAL_PROMETHEUS_TLS_SKIP_VERIFY").Bool()
@@ -163,6 +164,9 @@ func (cfg *Config) ApplyFlags() {
 	}
 	if *globalClickhouseTlsSkipVerify {
 		cfg.GlobalClickhouse.TlsSkipVerify = *globalClickhouseTlsSkipVerify
+	}
+	if *globalClickhouseTlsCAFile != "" {
+		cfg.GlobalClickhouse.TlsCAFile = *globalClickhouseTlsCAFile
 	}
 	if !keep {
 		cfg.GlobalClickhouse = nil

--- a/db/integrations.go
+++ b/db/integrations.go
@@ -171,6 +171,7 @@ type IntegrationClickhouse struct {
 	InitialDatabase string          `json:"-"`
 	TlsEnable       bool            `json:"tls_enable"`
 	TlsSkipVerify   bool            `json:"tls_skip_verify"`
+	TlsCAFile       string          `json:"tls_ca_file"`
 }
 
 type IntegrationSlack struct {

--- a/docs/docs/configuration/configuration.md
+++ b/docs/docs/configuration/configuration.md
@@ -53,6 +53,7 @@ For instance, the `projects` parameter (a list of predefined projects) can only 
 | --global-clickhouse-initial-database | GLOBAL_CLICKHOUSE_INITIAL_DATABASE |               | The initial database on the ClickHouse server to be used for all projects. Coroot will automatically create and manage a dedicated database for each project within the server. |
 | --global-clickhouse-tls-enabled      | GLOBAL_CLICKHOUSE_TLS_ENABLED      | false         | Whether TLS is enabled for the ClickHouse server connection (true or false).                                                                                                    |
 | --global-clickhouse-tls-skip-verify  | GLOBAL_CLICKHOUSE_TLS_SKIP_VERIFY  | false         | Whether to skip verification of the ClickHouse server's TLS certificate (true or false).                                                                                        |
+| --global-clickhouse-tls-ca-file      | GLOBAL_CLICKHOUSE_TLS_CA_FILE      |               | Path to the CA certificate file for ClickHouse TLS verification.                                                                                                              |
 | --global-prometheus-url              | GLOBAL_PROMETHEUS_URL              |               | The URL of the Prometheus server to be used for all projects.                                                                                                                   |
 | --global-prometheus-tls-skip-verify  | GLOBAL_PROMETHEUS_TLS_SKIP_VERIFY  | false         | Whether to skip verification of the Prometheus server's TLS certificate (true or false).                                                                                        |
 | --global-refresh-interval            | GLOBAL_REFRESH_INTERVAL            | 15s           | The interval for refreshing Prometheus data.                                                                                                                                    |
@@ -124,6 +125,7 @@ global_clickhouse: # The ClickHouse server to be used for all projects.
   database:              # The initial database on the ClickHouse server.
   tls_enable: false      # Whether TLS is enabled for the ClickHouse server connection.
   tls_skip_verify: false # Whether to skip verification of the ClickHouse server's TLS certificate.
+  tls_ca_file:           # Path to a custom CA certificate file for ClickHouse TLS verification.
 
 clickhouse_space_manager: # Automatically manage ClickHouse disk space by cleaning up old partitions.
   enabled: true                    # Enable space manager (default: true).


### PR DESCRIPTION
Added env variable to support TLS CA file verification for clickhouse server. 

Reference: https://github.com/coroot/coroot-node-agent/pull/299