### PR TITLE
Show global search hint when application filters return no matches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ docker build -f dev.dockerfile -t coroot-dev .
 
 Run:
 ```shell
-docker run --rm -p 8080:127.0.0.1:8080 -d coroot-dev
+docker run --rm -p 127.0.0.1:8080:8080 -d coroot-dev
 ```
 
 Open http://127.0.0.1:8080 in your browser.

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -18,7 +18,7 @@
                     </router-link>
                 </div>
                 <v-list v-if="project" dense class="pa-0">
-                    <v-list-item @click="search = true">
+                    <v-list-item @click="openSearch()">
                         <v-list-item-icon class="mr-3">
                             <v-icon dark>mdi-magnify</v-icon>
                         </v-list-item-icon>
@@ -243,7 +243,7 @@
 
                 <CloudPromoDialog v-if="!ee && user" />
 
-                <Search v-if="search" v-model="search" />
+                <Search v-if="search" v-model="search" :initial-search="searchQuery" />
             </v-container>
         </v-main>
     </v-app>
@@ -275,12 +275,14 @@ export default {
             changePassword: false,
             menuCollapsed: menuCollapsed,
             search: false,
+            searchQuery: '',
             systemAlerts: [],
         };
     },
 
     mounted() {
         this.$events.watch(this, this.getUser, 'projects');
+        this.$events.watch(this, () => this.openSearch(this.$events.searchQuery), 'search');
         this.getUser();
         window.addEventListener('keydown', this.searchListener);
     },
@@ -435,8 +437,12 @@ export default {
         searchListener(e) {
             if (this.project && (e.metaKey || e.ctrlKey) && e.key === 'k') {
                 e.preventDefault();
-                this.search = true;
+                this.openSearch();
             }
+        },
+        openSearch(query = '') {
+            this.searchQuery = query;
+            this.search = true;
         },
         toggleSystemAlert(name, show) {
             const set = new Set(this.systemAlerts);

--- a/front/src/components/SearchMore.vue
+++ b/front/src/components/SearchMore.vue
@@ -1,0 +1,17 @@
+<template>
+    <div class="pa-4 text-center grey--text">
+        No applications found in this view.
+        <v-btn text small color="primary" @click="$events.openSearch(query)">
+            <v-icon small left>mdi-magnify</v-icon>
+            Search all apps and nodes
+        </v-btn>
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        query: String,
+    },
+};
+</script>

--- a/front/src/utils/events.js
+++ b/front/src/utils/events.js
@@ -7,7 +7,9 @@ export default new Vue({
                 refresh: 0,
                 projects: 0,
                 roles: 0,
+                search: 0,
             },
+            searchQuery: '',
         };
     },
 
@@ -34,6 +36,10 @@ export default new Vue({
                 return;
             }
             this.events[event]++;
+        },
+        openSearch(query = '') {
+            this.searchQuery = query;
+            this.emit('search');
         },
     },
 });

--- a/front/src/views/Applications.vue
+++ b/front/src/views/Applications.vue
@@ -1,6 +1,6 @@
 <template>
     <Views :loading="loading" :error="error">
-        <ApplicationFilter :applications="applications" @filter="setFilter" class="mb-4" />
+        <ApplicationFilter :applications="applications" @filter="setFilter" @search="setSearch" class="mb-4" />
 
         <div class="legend mb-3">
             <div v-for="s in statuses" class="item">
@@ -19,6 +19,10 @@
             :headers="headers"
             :footer-props="{ itemsPerPageOptions: [10, 20, 50, 100, -1] }"
         >
+            <template #no-data>
+                <SearchMore v-if="search" :query="search" />
+                <template v-else>No applications found</template>
+            </template>
             <template #item.application="{ item: { id, name, ns, color } }">
                 <div class="application">
                     <div class="status" :class="color" />
@@ -98,6 +102,7 @@
 <script>
 import ApplicationFilter from '../components/ApplicationFilter.vue';
 import AppIcon from '../components/AppIcon.vue';
+import SearchMore from '../components/SearchMore.vue';
 import Views from '@/views/Views.vue';
 
 const statuses = {
@@ -109,12 +114,13 @@ const statuses = {
 };
 
 export default {
-    components: { Views, ApplicationFilter, AppIcon },
+    components: { Views, ApplicationFilter, AppIcon, SearchMore },
 
     data() {
         return {
             applications: [],
             filter: new Set(),
+            search: '',
             loading: false,
             error: '',
         };
@@ -205,6 +211,9 @@ export default {
         },
         setFilter(filter) {
             this.filter = filter;
+        },
+        setSearch(search) {
+            this.search = search;
         },
         link(id, report, query) {
             return { name: 'overview', params: { view: 'applications', id, report }, query: { ...query, ...this.$utils.contextQuery() } };

--- a/front/src/views/Search.vue
+++ b/front/src/views/Search.vue
@@ -72,12 +72,13 @@
 export default {
     props: {
         value: Boolean,
+        initialSearch: String,
     },
 
     data() {
         return {
             context: this.$api.context,
-            search: '',
+            search: this.initialSearch || '',
             loading: false,
             error: '',
             dialog: this.value,

--- a/front/src/views/ServiceMap.vue
+++ b/front/src/views/ServiceMap.vue
@@ -2,11 +2,20 @@
     <Views :loading="loading" :error="error">
         <NoData v-if="!loading && !applications.length" />
 
-        <ApplicationFilter v-else :applications="applications" :autoSelectNamespaceThreshold="maxApplications" @filter="setFilter" class="mb-4" />
+        <ApplicationFilter
+            v-else
+            :applications="applications"
+            :autoSelectNamespaceThreshold="maxApplications"
+            @filter="setFilter"
+            @search="setSearch"
+            class="mb-4"
+        />
 
         <div v-if="tooManyApplications" class="text-center red--text mt-5">
             Too many applications ({{ tooManyApplications }}) to render. Please choose a different category or namespace.
         </div>
+
+        <SearchMore v-else-if="search && !levels.length" :query="search" />
 
         <div class="applications" v-on-resize="calc" @scroll="calc">
             <div
@@ -79,6 +88,7 @@ import AppIcon from '@/components/AppIcon.vue';
 import ApplicationFilter from '@/components/ApplicationFilter.vue';
 import AppPreferences from '@/components/AppPreferences.vue';
 import NoData from '@/components/NoData.vue';
+import SearchMore from '@/components/SearchMore.vue';
 
 function findBackLinks(index, a, discovered, finished, found) {
     if (!a) {
@@ -115,7 +125,7 @@ function calcLevel(index, a, level, backLinks) {
 }
 
 export default {
-    components: { Views, NoData, AppPreferences, ApplicationFilter, AppHealth, Labels, AppIcon },
+    components: { Views, NoData, SearchMore, AppPreferences, ApplicationFilter, AppHealth, Labels, AppIcon },
 
     data() {
         return {
@@ -127,6 +137,7 @@ export default {
             arrows: [],
             hi: null,
             filter: new Set(),
+            search: '',
             tooManyApplications: 0,
         };
     },
@@ -173,6 +184,9 @@ export default {
         setFilter(filter) {
             this.filter = filter;
             this.calc();
+        },
+        setSearch(search) {
+            this.search = search;
         },
         calc() {
             if (!this.applications) {


### PR DESCRIPTION
<img width="992" height="312" alt="image" src="https://github.com/user-attachments/assets/47475377-98c1-43d1-9a1d-c54916d4f6b5" />

<img width="879" height="288" alt="image" src="https://github.com/user-attachments/assets/95754909-b4c8-405b-94c8-f6ef574e7bde" />


Chnages:

- when a search yields no results, prompt the user to try "Search all".
- doc: fix docker port


Background:

Hi, I used Coroot for the first time yesterday and have no prior experience with similar products.
I noticed that some of my containers were missing from the "Applications" and "Service Maps" views, and I couldn't find them using the standard search bar.

At first, I suspected the node-agent was failing to capture data for those containers. It took me some time to realize that Coroot only lists an app under "Applications" and "Service Maps" if it meets specific criteria (such as communicating with other apps).

Furthermore, it seems that the only way to find these hidden apps is by using the "Go to... (Ctrl+K)" button in the sidebar to open the dedicated pop-up search window.
I find this design somewhat counter-intuitive.
buttons in that location are typically used for global navigation to specific pages or settings (like in the CloudFlare Dashboard).
Given that both the "Applications" and "Service Maps" pages have their own search functions, I didn't expect the "Go to... (Ctrl+K)" feature to offer a deeper search scope than the page-specific search.

In fact, I spent tens of minutes yesterday tweaking search parameters, restarting containers, making noise before I finally stumbled upon the "Go to..." button.