### PR TITLE
config: expand environment variables after YAML parsing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -241,7 +241,7 @@ func Load() (*Config, error) {
 	}
 
 	if len(data) > 0 {
-		if err = yaml.Unmarshal(data, cfg); err != nil {
+		if err = unmarshalWithEnv(data, cfg); err != nil {
 			return nil, err
 		}
 	}
@@ -267,8 +267,39 @@ func ReadFromFile() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	data = []byte(os.ExpandEnv(string(data)))
 	return data, nil
+}
+
+// unmarshalWithEnv parses the config and expands environment variables in its
+// scalar values. Expanding after parsing keeps values with YAML-special
+// characters (e.g. an API key starting with "!") from being interpreted as
+// YAML syntax.
+func unmarshalWithEnv(data []byte, cfg *Config) error {
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return err
+	}
+	if root.Kind == 0 { // empty document
+		return nil
+	}
+	expandEnv(&root)
+	return root.Decode(cfg)
+}
+
+func expandEnv(n *yaml.Node) {
+	if n.Kind == yaml.ScalarNode {
+		if expanded := os.ExpandEnv(n.Value); expanded != n.Value {
+			n.Value = expanded
+			if n.Style == 0 && n.Tag == "!!str" {
+				// re-resolve the type of unquoted scalars, so values like
+				// `refresh_interval: $INTERVAL` decode into non-string fields
+				n.Tag = ""
+			}
+		}
+	}
+	for _, c := range n.Content {
+		expandEnv(c)
+	}
 }
 
 func (cfg *Config) Validate() error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshalWithEnv(t *testing.T) {
+	t.Setenv("TEST_API_KEY", "!random")
+	t.Setenv("TEST_PASSWORD", `p#ss: *word"x`)
+	t.Setenv("TEST_HOST", "myhost")
+	t.Setenv("TEST_INTERVAL", "30s")
+
+	data := []byte(`
+projects:
+  - name: default
+    apiKeys:
+      - key: ${TEST_API_KEY}
+global_prometheus:
+  url: http://$TEST_HOST:9090/prom
+  refresh_interval: $TEST_INTERVAL
+  password: ${TEST_PASSWORD}
+`)
+	cfg := NewConfig()
+	require.NoError(t, unmarshalWithEnv(data, cfg))
+
+	// values coming from the environment are used verbatim, even if they
+	// contain YAML-special characters (see #692)
+	require.Len(t, cfg.Projects, 1)
+	require.Len(t, cfg.Projects[0].ApiKeys, 1)
+	assert.Equal(t, "!random", cfg.Projects[0].ApiKeys[0].Key)
+	assert.Equal(t, `p#ss: *word"x`, cfg.GlobalPrometheus.Password)
+
+	// variables inside a larger scalar and in non-string fields still work
+	assert.Equal(t, "http://myhost:9090/prom", cfg.GlobalPrometheus.Url)
+	assert.Equal(t, "30s", cfg.GlobalPrometheus.RefreshInterval.String())
+}
+
+func TestUnmarshalWithEnvNoVariables(t *testing.T) {
+	data := []byte(`
+listen_address: ":8080"
+projects:
+  - name: default
+    apiKeys:
+      - key: static-key
+`)
+	cfg := NewConfig()
+	require.NoError(t, unmarshalWithEnv(data, cfg))
+	assert.Equal(t, ":8080", cfg.ListenAddress)
+	assert.Equal(t, "static-key", cfg.Projects[0].ApiKeys[0].Key)
+}
+
+func TestUnmarshalWithEnvEmptyDocument(t *testing.T) {
+	for _, data := range []string{"", "\n", "# only a comment\n"} {
+		cfg := NewConfig()
+		require.NoError(t, unmarshalWithEnv([]byte(data), cfg))
+	}
+}
+
+func TestUnmarshalWithEnvUndefinedVariable(t *testing.T) {
+	data := []byte(`
+projects:
+  - name: default
+    apiKeys:
+      - key: ${TEST_UNDEFINED_VAR}
+`)
+	cfg := NewConfig()
+	require.NoError(t, unmarshalWithEnv(data, cfg))
+	// undefined variables expand to an empty string, as before
+	assert.Equal(t, "", cfg.Projects[0].ApiKeys[0].Key)
+}
+
+func TestLoadExpandsEnvInValues(t *testing.T) {
+	// mirrors the coroot-operator flow: the config references a secret-backed
+	// API key via an environment variable (see #692)
+	t.Setenv("COROOT_CONFIG_SECRET_AB12CD34", "!random")
+
+	f := filepath.Join(t.TempDir(), "config.yaml")
+	data := []byte(`
+projects:
+  - name: default
+    apiKeys:
+      - key: ${COROOT_CONFIG_SECRET_AB12CD34}
+        description: default
+`)
+	require.NoError(t, os.WriteFile(f, data, 0o600))
+	prev := *configFile
+	*configFile = f
+	defer func() { *configFile = prev }()
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.Len(t, cfg.Projects, 1)
+	require.Len(t, cfg.Projects[0].ApiKeys, 1)
+	assert.Equal(t, "!random", cfg.Projects[0].ApiKeys[0].Key)
+}


### PR DESCRIPTION
The config loader ran `os.ExpandEnv` on the raw YAML text before parsing it, so an expanded value containing YAML-special characters changed the structure of the document. An API key starting with `!` — e.g. a secret-backed key written by coroot-operator as `key: ${COROOT_CONFIG_SECRET_...}` — was parsed as a YAML tag and silently became an empty key, and values containing `: ` or quotes made the config fail to parse.

This change parses the document first and then expands variables in its scalar values, so substituted values can never be interpreted as YAML syntax. Variables inside larger scalars (`url: http://$HOST:9090`) and in non-string fields (`refresh_interval: $INTERVAL`) keep working, undefined variables still expand to an empty string, and a config without variables is parsed exactly as before.

Tests cover the reported case end to end (a `Load()` from a file referencing a secret-backed `!random` key), plus special characters in passwords, compound scalars, non-string fields, empty documents, and undefined variables.

Fixes #692
