### PR TITLE
Harden CI/CD supply chain: pin actions, least-privilege permissions, Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/front"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,19 +6,22 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   GO:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
       - name: gofmt -l .
         run: files=$(gofmt -l .); if [[ -n "$files" ]]; then echo "$files"; exit 1; fi
       - name: goimports -l .
         run: |
-          go install golang.org/x/tools/cmd/goimports@latest
+          go install golang.org/x/tools/cmd/goimports@v0.39.0
           files=$(goimports -l .); if [[ -n "$files" ]]; then echo "$files"; exit 1; fi
       - run: mkdir static && touch static/file.txt && go vet ./...
       - run: go test ./...
@@ -29,8 +32,8 @@ jobs:
       run:
         working-directory: ./front/
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 24
       - run: npm ci

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,15 +12,18 @@ on:
     paths:
       - 'docs/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Docusaurus
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 24
           cache: npm
@@ -32,7 +35,7 @@ jobs:
         run: npm run build
 
       - name: Upload Build Artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: docs/build
 
@@ -52,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,15 +9,21 @@ env:
   IMAGE_NAME: ${{ github.repository }}
   VERSION: ${{ github.event.release.tag_name }}
 
+permissions:
+  contents: read
+
 jobs:
   build-frontend:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     defaults:
       run:
         working-directory: ./front/
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 24
           registry-url: 'https://npm.pkg.github.com'
@@ -27,13 +33,16 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run build-prod
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: static
           path: ./static
 
   build-images:
     needs: build-frontend
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: true
       matrix:
@@ -46,16 +55,16 @@ jobs:
             arch: arm64
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: static
           path: ./static
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -64,13 +73,13 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         id: build
         with:
           context: .
@@ -92,13 +101,13 @@ jobs:
           docker cp ${{ matrix.arch }}:/usr/bin/coroot /tmp/coroot-${{ matrix.arch }}
 
       - name: upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: digest-${{ matrix.arch }}
           path: /tmp/digests/${{ matrix.arch }}
 
       - name: upload ${{ matrix.arch }} binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: binary-${{ matrix.arch }}
           path: /tmp/coroot-${{ matrix.arch }}
@@ -106,15 +115,18 @@ jobs:
   release:
     needs: build-images
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      packages: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: /tmp/artifacts
           pattern: '{digest,binary}-*'
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -123,7 +135,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -136,7 +148,7 @@ jobs:
             $(for f in /tmp/artifacts/digest-*/*; do echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@$(cat $f)"; done)
 
       - name: upload amd64 binary
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -146,7 +158,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: upload arm64 binary
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -155,7 +167,7 @@ jobs:
           asset_name: coroot-arm64
           asset_content_type: application/octet-stream
 
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           RELEASE_ID: ${{ github.event.release.id }}
         with:

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ go-fmt:
 
 .PHONY: go-imports
 go-imports:
-	go install golang.org/x/tools/cmd/goimports@latest
+	go install golang.org/x/tools/cmd/goimports@v0.39.0
 	goimports -w .
 
 .PHONY: go-test


### PR DESCRIPTION
## Summary

This PR applies a standard, low-risk set of software supply-chain hardening practices to the GitHub Actions workflows, following an audit of the repo's CI/CD and dependency-update posture:

- **Pin all third-party GitHub Actions to a full commit SHA** (with the resolved version as a trailing comment) instead of mutable tags like `@v5`. Mutable tags can be repointed by a compromised or malicious action maintainer/account without any change on your side — this is exactly what happened in the `tj-actions/changed-files` supply-chain incident in March 2025. Pinning to SHA is the standard mitigation recommended by [GitHub's own hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and [OpenSSF Scorecard](https://github.com/ossf/scorecard).
- **Add explicit least-privilege `permissions:` blocks** to `ci.yml`, `docs.yml`, and `release.yml`. Previously `ci.yml` and `release.yml` had no `permissions:` key at all, meaning jobs ran with whatever the default `GITHUB_TOKEN` scope is configured to in the repo settings (which can be quite broad). Each workflow/job now declares only the scopes it actually needs (e.g. `packages: write` only in the jobs that push to GHCR/npm, `contents: write` only in the job that uploads release assets).
- **Pin `goimports` to a fixed version** (`v0.39.0`) instead of `@latest` in both `ci.yml` and the `Makefile`, so lint tooling behavior is reproducible and not silently affected by upstream releases.
- **Add `.github/dependabot.yml`** covering `gomod`, `npm` (both `front/` and `docs/`), `docker` (base images in `Dockerfile`), and `github-actions` ecosystems on a weekly cadence, with related updates grouped into single PRs to reduce noise. There was previously no automated dependency-update mechanism in the repo.

## Notes

- No behavior changes — every pinned action resolves to the exact same version currently referenced by the mutable tag, so this should be a no-op for CI behavior.
- Scope intentionally kept to config/CI-only changes (no source, Dockerfile digest-pinning, or image-signing changes) to keep this PR focused and easy to review. Happy to follow up with SBOM/provenance attestation and artifact checksums for `release.yml` in a separate PR if useful.

## Test plan

- [x] All modified YAML files validated with `yaml.safe_load`
- [x] Each pinned SHA resolved against the GitHub API and cross-checked against the corresponding version tag
- [x] No source code, Dockerfile, or workflow *logic* changed — diff is limited to action refs, `permissions:` blocks, a version pin, and the new dependabot config
- [ ] CI will run on this PR itself, exercising the updated `ci.yml`