### PR TITLE
fix(logs): allow filtering by trace ID

### DIFF
--- a/front/src/components/LogEntry.vue
+++ b/front/src/components/LogEntry.vue
@@ -16,6 +16,18 @@
             <div class="font-weight-medium mt-4 mb-2">Attributes</div>
             <v-simple-table dense class="attributes">
                 <tbody>
+                    <tr v-if="value.trace_id">
+                        <td class="name">Trace ID</td>
+                        <td class="value">{{ value.trace_id }}</td>
+                        <td class="text-right text-no-wrap ops">
+                            <v-btn small icon title="add to search" @click="filter('TraceId', '=', value.trace_id)">
+                                <v-icon small>mdi-plus</v-icon>
+                            </v-btn>
+                            <v-btn small icon title="exclude from search" @click="filter('TraceId', '!=', value.trace_id)">
+                                <v-icon small>mdi-minus</v-icon>
+                            </v-btn>
+                        </td>
+                    </tr>
                     <tr v-for="(v, k) in value.attributes">
                         <td class="name">{{ k }}</td>
                         <td class="value">


### PR DESCRIPTION
Fixes #978

Expose the trace ID in the log entry dialog with the existing include and exclude filter actions. The backend already supports the TraceId filter; this makes the UI path usable for JSON-ingested OpenTelemetry logs.

Validation:
- npm run lint -- --no-fix
- npm run build-prod